### PR TITLE
update file to use openai==1.57

### DIFF
--- a/Chapter11/Transfer_Learning_with_Ada_Embeddings.ipynb
+++ b/Chapter11/Transfer_Learning_with_Ada_Embeddings.ipynb
@@ -15,14 +15,14 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "V45zfsIfBniX"
+      },
       "source": [
         "**June 1, 2024 update**\n",
         "\n",
         "In recent versions of pandas (1.3.x onwards), the error_bad_lines parameter has been removed from pd.read_csv(). Instead, you should use the on_bad_lines parameter."
-      ],
-      "metadata": {
-        "id": "V45zfsIfBniX"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
@@ -35,64 +35,100 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": 1,
       "metadata": {
-        "id": "tU_uX-KCa_KK",
-        "outputId": "5a6c9451-e195-4c6b-fd6f-24f6b78a56b1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        }
+        "id": "tU_uX-KCa_KK"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting openai==0.28\n",
-            "  Downloading openai-0.28.0-py3-none-any.whl (76 kB)\n",
-            "\u001b[?25l     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/76.5 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.5/76.5 kB\u001b[0m \u001b[31m2.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: requests>=2.20 in /usr/local/lib/python3.10/dist-packages (from openai==0.28) (2.31.0)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.10/dist-packages (from openai==0.28) (4.66.4)\n",
-            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from openai==0.28) (3.9.5)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai==0.28) (3.3.2)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai==0.28) (3.7)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai==0.28) (2.0.7)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.20->openai==0.28) (2024.2.2)\n",
-            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (1.3.1)\n",
-            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (23.2.0)\n",
-            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (1.4.1)\n",
-            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (6.0.5)\n",
-            "Requirement already satisfied: yarl<2.0,>=1.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (1.9.4)\n",
-            "Requirement already satisfied: async-timeout<5.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->openai==0.28) (4.0.3)\n",
-            "Installing collected packages: openai\n",
-            "Successfully installed openai-0.28.0\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "try:\n",
         "  import openai\n",
         "except:\n",
-        "  !pip install openai==0.28\n",
+        "  !pip install --upgrade openai # installed 1.57\n",
         "  import openai"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Wy6XBCMmdLvM",
+        "outputId": "881cee63-d9cc-4ccc-affb-a58aba3476d0"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: openai in /usr/local/lib/python3.10/dist-packages (1.54.5)\n",
+            "Collecting openai\n",
+            "  Downloading openai-1.57.0-py3-none-any.whl.metadata (24 kB)\n",
+            "Requirement already satisfied: anyio<5,>=3.5.0 in /usr/local/lib/python3.10/dist-packages (from openai) (3.7.1)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /usr/local/lib/python3.10/dist-packages (from openai) (1.9.0)\n",
+            "Requirement already satisfied: httpx<1,>=0.23.0 in /usr/local/lib/python3.10/dist-packages (from openai) (0.28.0)\n",
+            "Requirement already satisfied: jiter<1,>=0.4.0 in /usr/local/lib/python3.10/dist-packages (from openai) (0.8.0)\n",
+            "Requirement already satisfied: pydantic<3,>=1.9.0 in /usr/local/lib/python3.10/dist-packages (from openai) (2.10.3)\n",
+            "Requirement already satisfied: sniffio in /usr/local/lib/python3.10/dist-packages (from openai) (1.3.1)\n",
+            "Requirement already satisfied: tqdm>4 in /usr/local/lib/python3.10/dist-packages (from openai) (4.66.6)\n",
+            "Requirement already satisfied: typing-extensions<5,>=4.11 in /usr/local/lib/python3.10/dist-packages (from openai) (4.12.2)\n",
+            "Requirement already satisfied: idna>=2.8 in /usr/local/lib/python3.10/dist-packages (from anyio<5,>=3.5.0->openai) (3.10)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio<5,>=3.5.0->openai) (1.2.2)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from httpx<1,>=0.23.0->openai) (2024.8.30)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx<1,>=0.23.0->openai) (1.0.7)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.14.0)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.10/dist-packages (from pydantic<3,>=1.9.0->openai) (0.7.0)\n",
+            "Requirement already satisfied: pydantic-core==2.27.1 in /usr/local/lib/python3.10/dist-packages (from pydantic<3,>=1.9.0->openai) (2.27.1)\n",
+            "Downloading openai-1.57.0-py3-none-any.whl (389 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m389.9/389.9 kB\u001b[0m \u001b[31m10.5 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: openai\n",
+            "  Attempting uninstall: openai\n",
+            "    Found existing installation: openai 1.54.5\n",
+            "    Uninstalling openai-1.54.5:\n",
+            "      Successfully uninstalled openai-1.54.5\n",
+            "Successfully installed openai-1.57.0\n",
+            "Collecting httpx<0.28\n",
+            "  Downloading httpx-0.27.2-py3-none-any.whl.metadata (7.1 kB)\n",
+            "Requirement already satisfied: anyio in /usr/local/lib/python3.10/dist-packages (from httpx<0.28) (3.7.1)\n",
+            "Requirement already satisfied: certifi in /usr/local/lib/python3.10/dist-packages (from httpx<0.28) (2024.8.30)\n",
+            "Requirement already satisfied: httpcore==1.* in /usr/local/lib/python3.10/dist-packages (from httpx<0.28) (1.0.7)\n",
+            "Requirement already satisfied: idna in /usr/local/lib/python3.10/dist-packages (from httpx<0.28) (3.10)\n",
+            "Requirement already satisfied: sniffio in /usr/local/lib/python3.10/dist-packages (from httpx<0.28) (1.3.1)\n",
+            "Requirement already satisfied: h11<0.15,>=0.13 in /usr/local/lib/python3.10/dist-packages (from httpcore==1.*->httpx<0.28) (0.14.0)\n",
+            "Requirement already satisfied: exceptiongroup in /usr/local/lib/python3.10/dist-packages (from anyio->httpx<0.28) (1.2.2)\n",
+            "Downloading httpx-0.27.2-py3-none-any.whl (76 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m76.4/76.4 kB\u001b[0m \u001b[31m3.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: httpx\n",
+            "  Attempting uninstall: httpx\n",
+            "    Found existing installation: httpx 0.28.0\n",
+            "    Uninstalling httpx-0.28.0:\n",
+            "      Successfully uninstalled httpx-0.28.0\n",
+            "Successfully installed httpx-0.27.2\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install --upgrade \"httpx<0.28\" # httpx-0.27.2"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "M-oZZR__a_sB",
-        "outputId": "d72a49dc-4918-4785-da03-069b8a9d83e4"
+        "outputId": "6ce34887-7c3e-48d7-b603-08924008e353"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "Drive already mounted at /content/drive; to attempt to forcibly remount, call drive.mount(\"/content/drive\", force_remount=True).\n"
+            "Mounted at /content/drive\n"
           ]
         }
       ],
@@ -103,7 +139,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 3,
       "metadata": {
         "id": "RRBQMmiAbJ7r"
       },
@@ -144,24 +180,25 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "zm7_zUuxgPzr",
-        "outputId": "f5eb522b-c6c9-49de-dcab-ed8db5cae42e"
+        "outputId": "2a6268f1-7394-4d9f-ad83-b24cd2d8e62d"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Collecting tiktoken\n",
-            "  Downloading tiktoken-0.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.1 MB)\n",
-            "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.1/1.1 MB\u001b[0m \u001b[31m8.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hRequirement already satisfied: regex>=2022.1.18 in /usr/local/lib/python3.10/dist-packages (from tiktoken) (2024.5.15)\n",
-            "Requirement already satisfied: requests>=2.26.0 in /usr/local/lib/python3.10/dist-packages (from tiktoken) (2.31.0)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (3.3.2)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (3.7)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (2.0.7)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (2024.2.2)\n",
-            "Installing collected packages: tiktoken\n",
-            "Successfully installed tiktoken-0.7.0\n"
+            "  Downloading tiktoken-0.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.6 kB)\n",
+            "Requirement already satisfied: regex>=2022.1.18 in /usr/local/lib/python3.10/dist-packages (from tiktoken) (2024.9.11)\n",
+            "Requirement already satisfied: requests>=2.26.0 in /usr/local/lib/python3.10/dist-packages (from tiktoken) (2.32.3)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.26.0->tiktoken) (2024.8.30)\n",
+            "Downloading tiktoken-0.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.2 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.2/1.2 MB\u001b[0m \u001b[31m18.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: tiktoken\n",
+            "Successfully installed tiktoken-0.8.0\n"
           ]
         }
       ],
@@ -254,24 +291,22 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 42,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "26i1JaHZiUeK",
-        "outputId": "7b6a0c4f-e2a7-492e-9a20-444775b12e7e"
+        "outputId": "4e6b6c0e-2735-44dd-a823-d31721702303"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Dataset URL: https://www.kaggle.com/datasets/snap/amazon-fine-food-reviews\n",
             "License(s): CC0-1.0\n",
-            "Downloading amazon-fine-food-reviews.zip to /content\n",
-            " 93% 225M/242M [00:02<00:00, 94.5MB/s]\n",
-            "100% 242M/242M [00:02<00:00, 103MB/s] \n"
+            "amazon-fine-food-reviews.zip: Skipping, found more recently modified local copy (use --force to force download)\n"
           ]
         }
       ],
@@ -281,7 +316,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 43,
       "metadata": {
         "id": "Rs2iBiyHpVXV"
       },
@@ -307,7 +342,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 44,
       "metadata": {
         "id": "OHT73Eb4fDVj"
       },
@@ -315,14 +350,12 @@
       "source": [
         "# imports\n",
         "import pandas as pd\n",
-        "import tiktoken\n",
-        "\n",
-        "from openai.embeddings_utils import get_embedding"
+        "import tiktoken"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": 45,
       "metadata": {
         "id": "S2BcOSwHfQfa"
       },
@@ -336,75 +369,25 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": 46,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 758
+          "height": 394
         },
         "id": "X6nFUwO_fT-v",
-        "outputId": "feefab8d-83fb-4f95-bd72-990d5152851b"
+        "outputId": "5ebdf314-6cd1-4c81-9bfa-fb9d08a5338c"
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
-            "text/plain": [
-              "          Time   ProductId          UserId  Score  \\\n",
-              "Id                                                  \n",
-              "1   1303862400  B001E4KFG0  A3SGXH7AUHU8GW      5   \n",
-              "2   1346976000  B00813GRG4  A1D87F6ZCVE5NK      1   \n",
-              "3   1219017600  B000LQOCH0   ABXLMWJIXXAIN      4   \n",
-              "4   1307923200  B000UA0QIQ  A395BORC6FGVXV      2   \n",
-              "5   1350777600  B006K2ZZ7K  A1UQRSCLF8GW1T      5   \n",
-              "6   1342051200  B006K2ZZ7K   ADT0SRK1MGOEU      4   \n",
-              "7   1340150400  B006K2ZZ7K  A1SP2KVKFXXRU1      5   \n",
-              "8   1336003200  B006K2ZZ7K  A3JRGQVEQN31IQ      5   \n",
-              "9   1322006400  B000E7L2R4  A1MZYO9TZK0BBI      5   \n",
-              "10  1351209600  B00171APVA  A21BT40VZCCYT4      5   \n",
-              "\n",
-              "                                          Summary  \\\n",
-              "Id                                                  \n",
-              "1                           Good Quality Dog Food   \n",
-              "2                               Not as Advertised   \n",
-              "3                           \"Delight\" says it all   \n",
-              "4                                  Cough Medicine   \n",
-              "5                                     Great taffy   \n",
-              "6                                      Nice Taffy   \n",
-              "7   Great!  Just as good as the expensive brands!   \n",
-              "8                          Wonderful, tasty taffy   \n",
-              "9                                      Yay Barley   \n",
-              "10                               Healthy Dog Food   \n",
-              "\n",
-              "                                                 Text  \\\n",
-              "Id                                                      \n",
-              "1   I have bought several of the Vitality canned d...   \n",
-              "2   Product arrived labeled as Jumbo Salted Peanut...   \n",
-              "3   This is a confection that has been around a fe...   \n",
-              "4   If you are looking for the secret ingredient i...   \n",
-              "5   Great taffy at a great price.  There was a wid...   \n",
-              "6   I got a wild hair for taffy and ordered this f...   \n",
-              "7   This saltwater taffy had great flavors and was...   \n",
-              "8   This taffy is so good.  It is very soft and ch...   \n",
-              "9   Right now I'm mostly just sprouting this so my...   \n",
-              "10  This is a very healthy dog food. Good for thei...   \n",
-              "\n",
-              "                                             combined  \n",
-              "Id                                                     \n",
-              "1   Title: Good Quality Dog Food; Content: I have ...  \n",
-              "2   Title: Not as Advertised; Content: Product arr...  \n",
-              "3   Title: \"Delight\" says it all; Content: This is...  \n",
-              "4   Title: Cough Medicine; Content: If you are loo...  \n",
-              "5   Title: Great taffy; Content: Great taffy at a ...  \n",
-              "6   Title: Nice Taffy; Content: I got a wild hair ...  \n",
-              "7   Title: Great!  Just as good as the expensive b...  \n",
-              "8   Title: Wonderful, tasty taffy; Content: This t...  \n",
-              "9   Title: Yay Barley; Content: Right now I'm most...  \n",
-              "10  Title: Healthy Dog Food; Content: This is a ve...  "
-            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "dataframe",
+              "variable_name": "df"
+            },
             "text/html": [
               "\n",
-              "  <div id=\"df-55f75128-ad04-47f1-b6c1-6252905d6a6e\" class=\"colab-df-container\">\n",
+              "  <div id=\"df-fed4566b-92a1-47c7-b46a-46b5d792b87c\" class=\"colab-df-container\">\n",
               "    <div>\n",
               "<style scoped>\n",
               "    .dataframe tbody tr th:only-of-type {\n",
@@ -549,7 +532,7 @@
               "    <div class=\"colab-df-buttons\">\n",
               "\n",
               "  <div class=\"colab-df-container\">\n",
-              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-55f75128-ad04-47f1-b6c1-6252905d6a6e')\"\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-fed4566b-92a1-47c7-b46a-46b5d792b87c')\"\n",
               "            title=\"Convert this dataframe to an interactive table.\"\n",
               "            style=\"display:none;\">\n",
               "\n",
@@ -601,12 +584,12 @@
               "\n",
               "    <script>\n",
               "      const buttonEl =\n",
-              "        document.querySelector('#df-55f75128-ad04-47f1-b6c1-6252905d6a6e button.colab-df-convert');\n",
+              "        document.querySelector('#df-fed4566b-92a1-47c7-b46a-46b5d792b87c button.colab-df-convert');\n",
               "      buttonEl.style.display =\n",
               "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "      async function convertToInteractive(key) {\n",
-              "        const element = document.querySelector('#df-55f75128-ad04-47f1-b6c1-6252905d6a6e');\n",
+              "        const element = document.querySelector('#df-fed4566b-92a1-47c7-b46a-46b5d792b87c');\n",
               "        const dataTable =\n",
               "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                    [key], {});\n",
@@ -626,8 +609,8 @@
               "  </div>\n",
               "\n",
               "\n",
-              "<div id=\"df-bfeda2ce-30ab-4caf-bfae-fcc4d2aedcf7\">\n",
-              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-bfeda2ce-30ab-4caf-bfae-fcc4d2aedcf7')\"\n",
+              "<div id=\"df-c4507741-aa17-4a8d-a18b-c80cd5903220\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-c4507741-aa17-4a8d-a18b-c80cd5903220')\"\n",
               "            title=\"Suggest charts\"\n",
               "            style=\"display:none;\">\n",
               "\n",
@@ -746,22 +729,73 @@
               "    }\n",
               "    (() => {\n",
               "      let quickchartButtonEl =\n",
-              "        document.querySelector('#df-bfeda2ce-30ab-4caf-bfae-fcc4d2aedcf7 button');\n",
+              "        document.querySelector('#df-c4507741-aa17-4a8d-a18b-c80cd5903220 button');\n",
               "      quickchartButtonEl.style.display =\n",
               "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "    })();\n",
               "  </script>\n",
               "</div>\n",
+              "\n",
               "    </div>\n",
               "  </div>\n"
             ],
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "dataframe",
-              "variable_name": "df"
-            }
+            "text/plain": [
+              "          Time   ProductId          UserId  Score  \\\n",
+              "Id                                                  \n",
+              "1   1303862400  B001E4KFG0  A3SGXH7AUHU8GW      5   \n",
+              "2   1346976000  B00813GRG4  A1D87F6ZCVE5NK      1   \n",
+              "3   1219017600  B000LQOCH0   ABXLMWJIXXAIN      4   \n",
+              "4   1307923200  B000UA0QIQ  A395BORC6FGVXV      2   \n",
+              "5   1350777600  B006K2ZZ7K  A1UQRSCLF8GW1T      5   \n",
+              "6   1342051200  B006K2ZZ7K   ADT0SRK1MGOEU      4   \n",
+              "7   1340150400  B006K2ZZ7K  A1SP2KVKFXXRU1      5   \n",
+              "8   1336003200  B006K2ZZ7K  A3JRGQVEQN31IQ      5   \n",
+              "9   1322006400  B000E7L2R4  A1MZYO9TZK0BBI      5   \n",
+              "10  1351209600  B00171APVA  A21BT40VZCCYT4      5   \n",
+              "\n",
+              "                                          Summary  \\\n",
+              "Id                                                  \n",
+              "1                           Good Quality Dog Food   \n",
+              "2                               Not as Advertised   \n",
+              "3                           \"Delight\" says it all   \n",
+              "4                                  Cough Medicine   \n",
+              "5                                     Great taffy   \n",
+              "6                                      Nice Taffy   \n",
+              "7   Great!  Just as good as the expensive brands!   \n",
+              "8                          Wonderful, tasty taffy   \n",
+              "9                                      Yay Barley   \n",
+              "10                               Healthy Dog Food   \n",
+              "\n",
+              "                                                 Text  \\\n",
+              "Id                                                      \n",
+              "1   I have bought several of the Vitality canned d...   \n",
+              "2   Product arrived labeled as Jumbo Salted Peanut...   \n",
+              "3   This is a confection that has been around a fe...   \n",
+              "4   If you are looking for the secret ingredient i...   \n",
+              "5   Great taffy at a great price.  There was a wid...   \n",
+              "6   I got a wild hair for taffy and ordered this f...   \n",
+              "7   This saltwater taffy had great flavors and was...   \n",
+              "8   This taffy is so good.  It is very soft and ch...   \n",
+              "9   Right now I'm mostly just sprouting this so my...   \n",
+              "10  This is a very healthy dog food. Good for thei...   \n",
+              "\n",
+              "                                             combined  \n",
+              "Id                                                     \n",
+              "1   Title: Good Quality Dog Food; Content: I have ...  \n",
+              "2   Title: Not as Advertised; Content: Product arr...  \n",
+              "3   Title: \"Delight\" says it all; Content: This is...  \n",
+              "4   Title: Cough Medicine; Content: If you are loo...  \n",
+              "5   Title: Great taffy; Content: Great taffy at a ...  \n",
+              "6   Title: Nice Taffy; Content: I got a wild hair ...  \n",
+              "7   Title: Great!  Just as good as the expensive b...  \n",
+              "8   Title: Wonderful, tasty taffy; Content: This t...  \n",
+              "9   Title: Yay Barley; Content: Right now I'm most...  \n",
+              "10  Title: Healthy Dog Food; Content: This is a ve...  "
+            ]
           },
+          "execution_count": 46,
           "metadata": {},
-          "execution_count": 14
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -778,20 +812,66 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": 47,
+      "metadata": {
+        "id": "tCtW6hPWDUY9"
+      },
+      "outputs": [],
+      "source": [
+        "## get_embedding function to replace openai's import -- written with help from gpt4o-mini ##\n",
+        "\n",
+        "import requests\n",
+        "import os\n",
+        "\n",
+        "def get_embedding(text_string):\n",
+        "    # Get the OpenAI API key from environment variable\n",
+        "    api_key = os.getenv(\"OPENAI_API_KEY\")\n",
+        "\n",
+        "    if api_key is None:\n",
+        "        raise ValueError(\"Please set the OPENAI_API_KEY environment variable.\")\n",
+        "\n",
+        "    # Set the API endpoint\n",
+        "    url = \"https://api.openai.com/v1/embeddings\"\n",
+        "\n",
+        "    # Set the headers for the request\n",
+        "    headers = {\n",
+        "        \"Content-Type\": \"application/json\",\n",
+        "        \"Authorization\": f\"Bearer {api_key}\"\n",
+        "    }\n",
+        "\n",
+        "    # Set the data payload for the request\n",
+        "    data = {\n",
+        "        \"input\": text_string,\n",
+        "        \"model\": \"text-embedding-ada-002\" # embedding_model\n",
+        "    }\n",
+        "\n",
+        "    # Make the POST request to the OpenAI API\n",
+        "    response = requests.post(url, headers=headers, json=data)\n",
+        "\n",
+        "    # Check for successful response\n",
+        "    if response.status_code == 200:\n",
+        "        data = json.loads(response.text)\n",
+        "        return data['data'][0]['embedding']\n",
+        "    else:\n",
+        "        raise Exception(f\"Error: {response.status_code}, Message: {response.text}\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 48,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Y37hFrtqfXHR",
-        "outputId": "dbd7dc4e-e3ac-48f4-d395-0bfa97c1985e"
+        "outputId": "cc55d9bf-51e0-47cf-c834-9603534f5332"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
-            "<ipython-input-15-03f7096fffed>:4: SettingWithCopyWarning: \n",
+            "<ipython-input-48-03f7096fffed>:4: SettingWithCopyWarning: \n",
             "A value is trying to be set on a copy of a slice from a DataFrame\n",
             "\n",
             "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
@@ -799,14 +879,14 @@
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1000"
             ]
           },
+          "execution_count": 48,
           "metadata": {},
-          "execution_count": 15
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -824,6 +904,90 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 49,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 272
+        },
+        "id": "-q-sMsNBCkVS",
+        "outputId": "5bfdad5e-bdbe-42f9-e8cd-b1ab6446407a"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>combined</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Id</th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>284932</th>\n",
+              "      <td>Title: where does one  start...and stop... wit...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>220697</th>\n",
+              "      <td>Title: Arrived in pieces; Content: Not pleased...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>107908</th>\n",
+              "      <td>Title: It isn't blanc mange, but isn't bad . ....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>107800</th>\n",
+              "      <td>Title: These also have SALT and it's not sea s...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>205313</th>\n",
+              "      <td>Title: Happy with the product; Content: My dog...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> object</label>"
+            ],
+            "text/plain": [
+              "Id\n",
+              "284932    Title: where does one  start...and stop... wit...\n",
+              "220697    Title: Arrived in pieces; Content: Not pleased...\n",
+              "107908    Title: It isn't blanc mange, but isn't bad . ....\n",
+              "107800    Title: These also have SALT and it's not sea s...\n",
+              "205313    Title: Happy with the product; Content: My dog...\n",
+              "Name: combined, dtype: object"
+            ]
+          },
+          "execution_count": 49,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df.combined.head()"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "EBL_RfNHfdPT"
@@ -834,7 +998,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": 52,
       "metadata": {
         "id": "jrsgyEh_fZ3I"
       },
@@ -843,8 +1007,92 @@
         "# Ensure you have your API key set in your environment per the README: https://github.com/openai/openai-python#usage\n",
         "\n",
         "# This may take a few minutes\n",
-        "df[\"embedding\"] = df.combined.apply(lambda x: get_embedding(x, engine=embedding_model))\n",
+        "df[\"embedding\"] = df.combined.apply(lambda x: get_embedding(x))\n",
         "df.to_csv(\"fine_food_reviews_with_embeddings_1k.csv\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 53,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 272
+        },
+        "id": "Bexn7fs71aSq",
+        "outputId": "739e6061-4c37-414a-bf8e-26ad4013e311"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>embedding</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Id</th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>284932</th>\n",
+              "      <td>[0.0070034084, -0.027408825, 0.010529168, -0.0...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>220697</th>\n",
+              "      <td>[-0.02361912, -0.011889805, 0.00044177182, -0....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>107908</th>\n",
+              "      <td>[0.00020324656, 0.005294406, 0.0025072629, 0.0...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>107800</th>\n",
+              "      <td>[0.010425282, -0.0134039335, 0.0042622155, -0....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>205313</th>\n",
+              "      <td>[0.015307778, -0.0039019187, 0.017341862, -0.0...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> object</label>"
+            ],
+            "text/plain": [
+              "Id\n",
+              "284932    [0.0070034084, -0.027408825, 0.010529168, -0.0...\n",
+              "220697    [-0.02361912, -0.011889805, 0.00044177182, -0....\n",
+              "107908    [0.00020324656, 0.005294406, 0.0025072629, 0.0...\n",
+              "107800    [0.010425282, -0.0134039335, 0.0042622155, -0....\n",
+              "205313    [0.015307778, -0.0039019187, 0.017341862, -0.0...\n",
+              "Name: embedding, dtype: object"
+            ]
+          },
+          "execution_count": 53,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df.embedding.head()"
       ]
     },
     {
@@ -858,14 +1106,26 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": 67,
       "metadata": {
-        "id": "OpPti4DbszYg"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OpPti4DbszYg",
+        "outputId": "2fb62842-192b-42bf-a4da-70ccfc052e44"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Drive already mounted at /content/drive; to attempt to forcibly remount, call drive.mount(\"/content/drive\", force_remount=True).\n"
+          ]
+        }
+      ],
       "source": [
         "#f = open(\"drive/MyDrive/files/api_key.txt\", \"r\")\n",
-        "!cp /content/fine_food_reviews_with_embeddings_1k.csv drive/MyDrive/files/fine_food_reviews_with_embeddings_1k.csv"
+        "!cp /content/fine_food_reviews_with_embeddings_1k.csv drive/MyDrive/fine_food_reviews_with_embeddings_1k.csv"
       ]
     },
     {
@@ -881,6 +1141,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "h6067rOfBSGH"
+      },
       "source": [
         "**June 1, 2024 update**\n",
         "\n",
@@ -888,38 +1151,47 @@
         "\n",
         "```\n",
         "df = pd.read_csv('fine_food_reviews_with_embeddings_1k.csv', on_bad_lines='skip')```\n"
-      ],
-      "metadata": {
-        "id": "h6067rOfBSGH"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "execution_count": 22,
+      "execution_count": 10,
+      "metadata": {
+        "id": "MoZfw6hfXE3b"
+      },
+      "outputs": [],
+      "source": [
+        "# Retrieve embeddings if saved previously in Drive\n",
+        "#!cp drive/MyDrive/fine_food_reviews_with_embeddings_1k.csv /content/fine_food_reviews_with_embeddings_1k.csv"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "B4zeSTmMZkFm",
-        "outputId": "eeb14954-d080-49bd-a42a-40c32ec96e59"
+        "outputId": "52ee50f0-12ad-4264-e608-98fc3da29d78"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Number of bad lines: 1\n"
           ]
         },
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(1000, 1536)"
             ]
           },
+          "execution_count": 11,
           "metadata": {},
-          "execution_count": 22
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -953,6 +1225,377 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 293
+        },
+        "id": "Lu1uDTSWAa9M",
+        "outputId": "1402b30f-5ef5-4e08-828c-e576223b37cc"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "summary": "{\n  \"name\": \"df\",\n  \"rows\": 1000,\n  \"fields\": [\n    {\n      \"column\": \"Id\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 163299,\n        \"min\": 10,\n        \"max\": 566798,\n        \"num_unique_values\": 1000,\n        \"samples\": [\n          27424,\n          40274,\n          90215\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"ProductId\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 868,\n        \"samples\": [\n          \"B007PA30TG\",\n          \"B004EDHD1I\",\n          \"B0032CJY6E\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"UserId\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 708,\n        \"samples\": [\n          \"AJZKIQO848M2P\",\n          \"AZPT0S609H54D\",\n          \"A3HLLKGK6GTUPF\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Score\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1,\n        \"min\": 1,\n        \"max\": 5,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          1,\n          2,\n          4\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Summary\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 721,\n        \"samples\": [\n          \"These are not unsweetened cranberries\",\n          \"Excellent\",\n          \"Delicious!\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"Text\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 761,\n        \"samples\": [\n          \"I love this stuff! It's a God sent Remedy for hangovers!.... I understand the health concerns many people have and I can also see that this can be habit forming. I make sure I only take one every so often and not everyday.\",\n          \"I like the crunchy-ness of the middle, but it doesn't have a great flavor, basically just a very sweet taste without much substance. The chocolate around it is pretty sweet too. If you like really sweet candy and crunchy-ness then go ahead and get them, but there are much better chocolates out there.\",\n          \"When using a drip coffee maker, I often slipped in an extra spoonful of grounds to make my morning coffee extra strong so that the milk would not dilute it too much.  After recently having bought a Keurig, I was a bit disappointed at the somewhat watered-down light-bodied taste of most of the K-Cups which came as a sample with it.<br /><br />So my first inclination was to browse the Amazon reviews of several varieties of K-Cup coffee and take advantage of what others who like a nice strong bold cup of coffee had learnt by trial and error - and that was a good move!  I took you all at your word, ordered a 50-pack of this coffee on Monday, had my first cup of it this morning, and decided it was worth submitting my first ever review of any Amazon product ever, both to give it a 5-star rating myself and to thank those of you who take the time & trouble to give honest reviews for the benefit of people like me.<br /><br />So for the record, on a price and quality scale this is my new favourite K-Cup coffee.  Until now, my favourite on a pure quality scale was <a href=\\\"http://www.amazon.com/gp/product/B008C9QEVU\\\">Starbucks Caff&egrave; Verona, Dark Roast, 27-Count K-Cups for Keurig Brewers</a> (excellent but very pricey!) and for a bold-yet-affordable cup was <a href=\\\"http://www.amazon.com/gp/product/B006N3I3I4\\\">Green Mountain Coffee Double Black Diamond, K-Cup Portion Pack for Keurig Brewers 24-Count</a> (also excellent, and less pricey, but IMO not quite as nice in flavour as Emeril's \\\"Big Easy Bold\\\").<br /><br />For anyone looking for a nice strong full-bodied and flavourful K-Cup coffee which won't break the bank, do try this one. If you're like me you won't be disappointed.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"combined\",\n      \"properties\": {\n        \"dtype\": \"string\",\n        \"num_unique_values\": 762,\n        \"samples\": [\n          \"Title: Tasty!; Content: I purchased this to send to my son who's away at college. It was delivered right to his dorm room with very fast shipping. He loved it so much he called me to thank me, and sadly, he hardly ever calls me anymore! If you want your kids to call home, and have some good snack to get them through midterms then send them this.\",\n          \"Title: Good product; Content: I like that this is a better product for my pets but really for the price of it I couldn't afford to buy this all the time. My cat isn't very picky usually and she ate this, we usually buy her the friskies prime filets, the vet said it is better to not change their diet and buy different types of food and flavors all the time so we normally stick with the chicken. I am glad this is a chicken formula since that is what she is used to. If it weren't so expensive I would buy it all the time but I do have to budget. I take good care of my animals but I have to watch the cost so that the humans can eat and pay bills. I am trying to get a baby kitten to start on solid foods and I am trying with this since it is quality and it is easier for him to try and eat than the filets.<br />It is a good quality cat food but it loses one star for being more than I can afford to buy on a constant basis and the cans are very small so it would take more cans to feed a cat.\",\n          \"Title: Great stuff; Content: I use this to make a broth for noodles and soup. it reminds me of the days I spent in Japan. easy to use.\"\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"n_tokens\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 74,\n        \"min\": 28,\n        \"max\": 645,\n        \"num_unique_values\": 201,\n        \"samples\": [\n          82,\n          229,\n          41\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"embedding\",\n      \"properties\": {\n        \"dtype\": \"object\",\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
+              "type": "dataframe",
+              "variable_name": "df"
+            },
+            "text/html": [
+              "\n",
+              "  <div id=\"df-99e4ae3e-a96c-4931-88e1-b928dd974138\" class=\"colab-df-container\">\n",
+              "    <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Id</th>\n",
+              "      <th>ProductId</th>\n",
+              "      <th>UserId</th>\n",
+              "      <th>Score</th>\n",
+              "      <th>Summary</th>\n",
+              "      <th>Text</th>\n",
+              "      <th>combined</th>\n",
+              "      <th>n_tokens</th>\n",
+              "      <th>embedding</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>284932</td>\n",
+              "      <td>B003XPF9BO</td>\n",
+              "      <td>A3R7JR3FMEBXQB</td>\n",
+              "      <td>5</td>\n",
+              "      <td>where does one  start...and stop... with a tre...</td>\n",
+              "      <td>Wanted to save some to bring to my Chicago fam...</td>\n",
+              "      <td>Title: where does one  start...and stop... wit...</td>\n",
+              "      <td>52</td>\n",
+              "      <td>[0.0070034084, -0.027408825, 0.010529168, -0.0...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>220697</td>\n",
+              "      <td>B003JK537S</td>\n",
+              "      <td>A3JBPC3WFUT5ZP</td>\n",
+              "      <td>1</td>\n",
+              "      <td>Arrived in pieces</td>\n",
+              "      <td>Not pleased at all. When I opened the box, mos...</td>\n",
+              "      <td>Title: Arrived in pieces; Content: Not pleased...</td>\n",
+              "      <td>35</td>\n",
+              "      <td>[-0.02361912, -0.011889805, 0.00044177182, -0....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>107908</td>\n",
+              "      <td>B000JMBE7M</td>\n",
+              "      <td>AQX1N6A51QOKG</td>\n",
+              "      <td>4</td>\n",
+              "      <td>It isn't blanc mange, but isn't bad . . .</td>\n",
+              "      <td>I'm not sure that custard is really custard wi...</td>\n",
+              "      <td>Title: It isn't blanc mange, but isn't bad . ....</td>\n",
+              "      <td>267</td>\n",
+              "      <td>[0.00020324656, 0.005294406, 0.0025072629, 0.0...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>107800</td>\n",
+              "      <td>B004AHGBX4</td>\n",
+              "      <td>A2UY46X0OSNVUQ</td>\n",
+              "      <td>3</td>\n",
+              "      <td>These also have SALT and it's not sea salt.</td>\n",
+              "      <td>I like the fact that you can see what you're g...</td>\n",
+              "      <td>Title: These also have SALT and it's not sea s...</td>\n",
+              "      <td>239</td>\n",
+              "      <td>[0.010425282, -0.0134039335, 0.0042622155, -0....</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>205313</td>\n",
+              "      <td>B001BORBHO</td>\n",
+              "      <td>A1AFOYZ9HSM2CZ</td>\n",
+              "      <td>5</td>\n",
+              "      <td>Happy with the product</td>\n",
+              "      <td>My dog was suffering with itchy skin.  He had ...</td>\n",
+              "      <td>Title: Happy with the product; Content: My dog...</td>\n",
+              "      <td>86</td>\n",
+              "      <td>[0.015307778, -0.0039019187, 0.017341862, -0.0...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "    <div class=\"colab-df-buttons\">\n",
+              "\n",
+              "  <div class=\"colab-df-container\">\n",
+              "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-99e4ae3e-a96c-4931-88e1-b928dd974138')\"\n",
+              "            title=\"Convert this dataframe to an interactive table.\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
+              "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
+              "  </svg>\n",
+              "    </button>\n",
+              "\n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-buttons div {\n",
+              "      margin-bottom: 4px;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "    <script>\n",
+              "      const buttonEl =\n",
+              "        document.querySelector('#df-99e4ae3e-a96c-4931-88e1-b928dd974138 button.colab-df-convert');\n",
+              "      buttonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "      async function convertToInteractive(key) {\n",
+              "        const element = document.querySelector('#df-99e4ae3e-a96c-4931-88e1-b928dd974138');\n",
+              "        const dataTable =\n",
+              "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                    [key], {});\n",
+              "        if (!dataTable) return;\n",
+              "\n",
+              "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "          + ' to learn more about interactive tables.';\n",
+              "        element.innerHTML = '';\n",
+              "        dataTable['output_type'] = 'display_data';\n",
+              "        await google.colab.output.renderOutput(dataTable, element);\n",
+              "        const docLink = document.createElement('div');\n",
+              "        docLink.innerHTML = docLinkHtml;\n",
+              "        element.appendChild(docLink);\n",
+              "      }\n",
+              "    </script>\n",
+              "  </div>\n",
+              "\n",
+              "\n",
+              "<div id=\"df-cddf794d-8522-4e93-9ae5-8adae33a1e25\">\n",
+              "  <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-cddf794d-8522-4e93-9ae5-8adae33a1e25')\"\n",
+              "            title=\"Suggest charts\"\n",
+              "            style=\"display:none;\">\n",
+              "\n",
+              "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "     width=\"24px\">\n",
+              "    <g>\n",
+              "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
+              "    </g>\n",
+              "</svg>\n",
+              "  </button>\n",
+              "\n",
+              "<style>\n",
+              "  .colab-df-quickchart {\n",
+              "      --bg-color: #E8F0FE;\n",
+              "      --fill-color: #1967D2;\n",
+              "      --hover-bg-color: #E2EBFA;\n",
+              "      --hover-fill-color: #174EA6;\n",
+              "      --disabled-fill-color: #AAA;\n",
+              "      --disabled-bg-color: #DDD;\n",
+              "  }\n",
+              "\n",
+              "  [theme=dark] .colab-df-quickchart {\n",
+              "      --bg-color: #3B4455;\n",
+              "      --fill-color: #D2E3FC;\n",
+              "      --hover-bg-color: #434B5C;\n",
+              "      --hover-fill-color: #FFFFFF;\n",
+              "      --disabled-bg-color: #3B4455;\n",
+              "      --disabled-fill-color: #666;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart {\n",
+              "    background-color: var(--bg-color);\n",
+              "    border: none;\n",
+              "    border-radius: 50%;\n",
+              "    cursor: pointer;\n",
+              "    display: none;\n",
+              "    fill: var(--fill-color);\n",
+              "    height: 32px;\n",
+              "    padding: 0;\n",
+              "    width: 32px;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart:hover {\n",
+              "    background-color: var(--hover-bg-color);\n",
+              "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "    fill: var(--button-hover-fill-color);\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-quickchart-complete:disabled,\n",
+              "  .colab-df-quickchart-complete:disabled:hover {\n",
+              "    background-color: var(--disabled-bg-color);\n",
+              "    fill: var(--disabled-fill-color);\n",
+              "    box-shadow: none;\n",
+              "  }\n",
+              "\n",
+              "  .colab-df-spinner {\n",
+              "    border: 2px solid var(--fill-color);\n",
+              "    border-color: transparent;\n",
+              "    border-bottom-color: var(--fill-color);\n",
+              "    animation:\n",
+              "      spin 1s steps(1) infinite;\n",
+              "  }\n",
+              "\n",
+              "  @keyframes spin {\n",
+              "    0% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "      border-left-color: var(--fill-color);\n",
+              "    }\n",
+              "    20% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    30% {\n",
+              "      border-color: transparent;\n",
+              "      border-left-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    40% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-top-color: var(--fill-color);\n",
+              "    }\n",
+              "    60% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "    }\n",
+              "    80% {\n",
+              "      border-color: transparent;\n",
+              "      border-right-color: var(--fill-color);\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "    90% {\n",
+              "      border-color: transparent;\n",
+              "      border-bottom-color: var(--fill-color);\n",
+              "    }\n",
+              "  }\n",
+              "</style>\n",
+              "\n",
+              "  <script>\n",
+              "    async function quickchart(key) {\n",
+              "      const quickchartButtonEl =\n",
+              "        document.querySelector('#' + key + ' button');\n",
+              "      quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
+              "      quickchartButtonEl.classList.add('colab-df-spinner');\n",
+              "      try {\n",
+              "        const charts = await google.colab.kernel.invokeFunction(\n",
+              "            'suggestCharts', [key], {});\n",
+              "      } catch (error) {\n",
+              "        console.error('Error during call to suggestCharts:', error);\n",
+              "      }\n",
+              "      quickchartButtonEl.classList.remove('colab-df-spinner');\n",
+              "      quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
+              "    }\n",
+              "    (() => {\n",
+              "      let quickchartButtonEl =\n",
+              "        document.querySelector('#df-cddf794d-8522-4e93-9ae5-8adae33a1e25 button');\n",
+              "      quickchartButtonEl.style.display =\n",
+              "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "    })();\n",
+              "  </script>\n",
+              "</div>\n",
+              "\n",
+              "    </div>\n",
+              "  </div>\n"
+            ],
+            "text/plain": [
+              "       Id   ProductId          UserId  Score  \\\n",
+              "0  284932  B003XPF9BO  A3R7JR3FMEBXQB      5   \n",
+              "1  220697  B003JK537S  A3JBPC3WFUT5ZP      1   \n",
+              "2  107908  B000JMBE7M   AQX1N6A51QOKG      4   \n",
+              "3  107800  B004AHGBX4  A2UY46X0OSNVUQ      3   \n",
+              "4  205313  B001BORBHO  A1AFOYZ9HSM2CZ      5   \n",
+              "\n",
+              "                                             Summary  \\\n",
+              "0  where does one  start...and stop... with a tre...   \n",
+              "1                                  Arrived in pieces   \n",
+              "2          It isn't blanc mange, but isn't bad . . .   \n",
+              "3        These also have SALT and it's not sea salt.   \n",
+              "4                             Happy with the product   \n",
+              "\n",
+              "                                                Text  \\\n",
+              "0  Wanted to save some to bring to my Chicago fam...   \n",
+              "1  Not pleased at all. When I opened the box, mos...   \n",
+              "2  I'm not sure that custard is really custard wi...   \n",
+              "3  I like the fact that you can see what you're g...   \n",
+              "4  My dog was suffering with itchy skin.  He had ...   \n",
+              "\n",
+              "                                            combined  n_tokens  \\\n",
+              "0  Title: where does one  start...and stop... wit...        52   \n",
+              "1  Title: Arrived in pieces; Content: Not pleased...        35   \n",
+              "2  Title: It isn't blanc mange, but isn't bad . ....       267   \n",
+              "3  Title: These also have SALT and it's not sea s...       239   \n",
+              "4  Title: Happy with the product; Content: My dog...        86   \n",
+              "\n",
+              "                                           embedding  \n",
+              "0  [0.0070034084, -0.027408825, 0.010529168, -0.0...  \n",
+              "1  [-0.02361912, -0.011889805, 0.00044177182, -0....  \n",
+              "2  [0.00020324656, 0.005294406, 0.0025072629, 0.0...  \n",
+              "3  [0.010425282, -0.0134039335, 0.0042622155, -0....  \n",
+              "4  [0.015307778, -0.0039019187, 0.017341862, -0.0...  "
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "df.head()"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "37jjY_NKZkFp"
@@ -972,11 +1615,79 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 15,
       "metadata": {
-        "id": "JC8UGDkdZkFq"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 241
+        },
+        "id": "JC8UGDkdZkFq",
+        "outputId": "c516618d-6980-4588-82ef-412358836627"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>Score</th>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>Cluster</th>\n",
+              "      <th></th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>4.104839</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>4.191176</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>4.215613</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>4.308357</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div><br><label><b>dtype:</b> float64</label>"
+            ],
+            "text/plain": [
+              "Cluster\n",
+              "2    4.104839\n",
+              "0    4.191176\n",
+              "1    4.215613\n",
+              "3    4.308357\n",
+              "Name: Score, dtype: float64"
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "from sklearn.cluster import KMeans\n",
         "\n",
@@ -1001,11 +1712,37 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 14,
       "metadata": {
-        "id": "G3M3AQsuZkFr"
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 469
+        },
+        "id": "G3M3AQsuZkFr",
+        "outputId": "72a78431-9322-4f4f-979e-1d7a600e48c2"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "Text(0.5, 1.0, 'Clusters identified visualized in language 2d using t-SNE')"
+            ]
+          },
+          "execution_count": 14,
+          "metadata": {},
+          "output_type": "execute_result"
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAioAAAGzCAYAAAABsTylAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOy9d3wc9Z3//5ztvaqtuiXZcpFtYZliTI/BYLgcBkJJcgES8iUHgS933yS/y11ygUshyZVUyKVwTi45LgkEp0AILZQQMDG2ZVxlq7dV297bzO+PYddaFVu2ZVvAPHn4IXZ2duYzZffzmncVJEmSUFBQUFBQUFBYgKjO9AAUFBQUFBQUFGZDESoKCgoKCgoKCxZFqCgoKCgoKCgsWBShoqCgoKCgoLBgUYSKgoKCgoKCwoJFESoKCgoKCgoKCxZFqCgoKCgoKCgsWBShoqCgoKCgoLBgUYSKgoKCgoKCwoJFESrHQX19PbfddtuZHsZp5cc//jGCINDb23vMdc/0+REEgfvvv79o2fbt2zn//PMxm80IgkB7ezv3338/giDM674vueQSLrnkknnb3kzHciaYOo7juR/mk7neW/N93m677Tbq6+vnbXsKJ858f8fmgnL9FwaKUAG6urq48847aWhowGAwYLPZWL9+Pd/61rdIJBKnZQzxeJz777+fl1566bTs753K73//+zlPRJlMhg984AP4/X6+8Y1v8NOf/pS6urpTO0AFBYVpHDx4kM985jO0trZitVrxeDxcffXVvPnmm2d6aAuWhx9+mB//+MfH9Zk9e/Zwww03UFdXh8FgoKqqissvv5zvfOc7RevV19cjCAL33HPPtG289NJLCILA448/XliWf0CZ7d+2bdtO6BjniuaUbv0dwFNPPcUHPvAB9Ho9H/nIR2hpaSGdTvPqq6/y6U9/mn379vGDH/zglI8jHo/zwAMPAJz2p4aj8Td/8zfcfPPN6PX6Mz0UQBYqDz300IxiJZFIoNEcuaW7urro6+vjhz/8IXfccUdh+ec+9zn+4R/+4XQM94SZeiwLhYV2P0xloZ639zo/+tGPeOSRR7j++uu56667CIVCfP/73+e8887jD3/4Axs2bDjTQ5yRH/7wh4iieEb2/fDDD1NSUjJnK/Vrr73GpZdeSm1tLR//+MepqKhgYGCAbdu28a1vfWtGUfLDH/6Qz372s1RWVs5pH//yL//CokWLpi1vamqa0+dPlPf0N7qnp4ebb76Zuro6/vjHP+LxeArv3X333XR2dvLUU0+dwRGePLFYDLPZfMKfV6vVqNXqeRzRqcNgMBS9HhsbA8DhcBQt12g0C34ym3osC4WFfj8s1PP2XueWW27h/vvvx2KxFJZ99KMfZdmyZdx///0LVqhotdozPYQ58+Uvfxm73c727dun/eblfwsns2LFCjo6OvjqV7/Kt7/97Tnt46qrrmLt2rXzMdzj4j3t+vn6179ONBrlkUceKRIpeZqamvi///f/zvr52WIdZvLjv/nmm2zcuJGSkhKMRiOLFi3iox/9KAC9vb2UlpYC8MADDxTMaZOtBgcPHuSGG27A5XJhMBhYu3Ytv/3tb2fc78svv8xdd91FWVkZ1dXVAEQiEe677z7q6+vR6/WUlZVx+eWXs3PnzqOeo5mORZIkvvSlL1FdXY3JZOLSSy9l3759M34+GAxy3333UVNTg16vp6mpia997WtFTym9vb0IgsC//du/8YMf/IDGxkb0ej1nn30227dvL6x322238dBDDwEUmR3zTD5nt912GxdffDEAH/jABxAEoWCpmu26/exnP6OtrQ2j0YjL5eLmm29mYGBg2nr5MRqNRs455xz+9Kc/HfUc5mlpaeHSSy+dtlwURaqqqrjhhhtmPBaY2/WbLY5jqm8/nU7zz//8z7S1tWG32zGbzVx44YW8+OKLxzyGqfdD/lzO9G/yWERR5Jvf/CYrVqzAYDBQXl7OnXfeSSAQKNr+8dxbMzH1vOXH19nZyW233YbD4cBut3P77bcTj8fnvN3J/Nu//Rvnn38+brcbo9FIW1tbkZl88lg++clP8utf/5qWlhb0ej0rVqzgD3/4w7R1X3rpJdauXYvBYKCxsZHvf//70+7T/PdkJnfA1OPu6+vjrrvuorm5GaPRiNvt5gMf+MCMsUVvvfUWF198MUajkerqar70pS+xZcuWGWORnn76aS688ELMZjNWq5Wrr756Ttenra2tSKQAuN1uLrzwQg4cODBt/RP9jh3POZrLd2pqjMpcf6vyPPbYYyxfvhyDwUBLSwtbt26dU9xLfX09+/bt4+WXXy58n45lae/q6mLFihXTRApAWVnZjPv4yEc+wg9/+EOGh4ePuu0zzcJ+rDzF/O53v6OhoYHzzz//lO5nbGyMK664gtLSUv7hH/4Bh8NBb28vTzzxBAClpaV873vf42//9m/ZvHkz1113HQCrVq0CYN++faxfv56qqir+4R/+AbPZzC9/+UuuvfZafvWrX7F58+ai/d11112Ulpbyz//8z8RiMQA+8YlP8Pjjj/PJT36S5cuX4/P5ePXVVzlw4ABr1qw5ruP553/+Z770pS+xadMmNm3axM6dO7niiitIp9NF68XjcS6++GKGhoa48847qa2t5bXXXuOzn/0sXq+Xb37zm0XrP/roo0QiEe68804EQeDrX/861113Hd3d3Wi1Wu68806Gh4d57rnn+OlPf3rUMd55551UVVXxla98hXvvvZezzz6b8vLyWdf/8pe/zOc//3luvPFG7rjjDsbHx/nOd77DRRddxK5duwpf/kceeYQ777yT888/n/vuu4/u7m7e//7343K5qKmpOeqYbrrpJu6//35GRkaoqKgoLH/11VcZHh7m5ptvnvWz83n9wuEwP/rRj7jlllv4+Mc/TiQS4ZFHHmHjxo385S9/obW1dc7buu6666aZfXfs2ME3v/nNoh/HO++8kx//+Mfcfvvt3HvvvfT09PDd736XXbt28ec//7nw5DrXe+t4ufHGG1m0aBEPPvggO3fu5Ec/+hFlZWV87WtfO+5tfetb3+L9738/H/rQh0in0/z85z/nAx/4AE8++SRXX3110bqvvvoqTzzxBHfddRdWq5Vvf/vbXH/99fT39+N2uwHYtWsXV155JR6PhwceeIBcLse//Mu/FB5eToTt27fz2muvcfPNN1NdXU1vby/f+973uOSSS9i/fz8mkwmAoaEhLr30UgRB4LOf/Sxms5kf/ehHM7r2fvrTn3LrrbeyceNGvva1rxGPx/ne977HBRdcwK5du04o6HRkZISSkpKiZSfzHTseTuY7dazfKpDDCm666SZWrlzJgw8+SCAQ4GMf+xhVVVXHHNs3v/lN7rnnHiwWC//0T/8EcNTfL4C6ujpef/119u7dS0tLy5zOwT/90z/x3//933O2qoRCISYmJoqWCYJQuJdPGdJ7lFAoJAHSX//1X8/5M3V1ddKtt95aeP2FL3xBmukUbtmyRQKknp4eSZIkaevWrRIgbd++fdZtj4+PS4D0hS98Ydp773vf+6SVK1dKyWSysEwURen888+XFi9ePG2/F1xwgZTNZou2YbfbpbvvvnuORzr7sYyNjUk6nU66+uqrJVEUC+v94z/+owQUnZ8vfvGLktlslg4dOlS0zX/4h3+Q1Gq11N/fL0mSJPX09EiA5Ha7Jb/fX1jvN7/5jQRIv/vd7wrL7r777hnPuSRJ087fiy++KAHSY489VrTe1OvW29srqdVq6ctf/nLRenv27JE0Gk1heTqdlsrKyqTW1lYplUoV1vvBD34gAdLFF18847jydHR0SID0ne98p2j5XXfdJVksFikej896LHO5flPvzzwXX3xx0diy2WzR+CVJkgKBgFReXi599KMfLVo+dRxT74epjI+PS7W1tdLKlSulaDQqSZIk/elPf5IA6X/+53+K1v3DH/5QtPx47q3ZmDre/LWeelybN2+W3G73Mbd36623SnV1dUXLJl8nSZLvi5aWFumyyy6bNhadTid1dnYWlu3evXvaPfBXf/VXkslkkoaGhgrLDh8+LGk0mqL7NP892bJlyzGPe+oYJUmSXn/9dQmQ/vu//7uw7J577pEEQZB27dpVWObz+SSXy1V0nSORiORwOKSPf/zjRdscGRmR7Hb7tOVz4ZVXXpEEQZA+//nPF5ad7HfseM7RXL5TU6//8fxWrVy5UqqurpYikUhh2UsvvSQB0+6pmVixYsUxj3cyzz77rKRWqyW1Wi2tW7dO+sxnPiM988wzUjqdnrZuXV2ddPXVV0uSJEm33367ZDAYpOHhYUmSZv7dzH/vZ/qn1+vnPMYT5T3r+gmHwwBYrdZTvq/80/iTTz5JJpM5rs/6/X7++Mc/cuONNxKJRJiYmGBiYgKfz8fGjRs5fPgwQ0NDRZ/5+Mc/Pi2OwOFw8MYbb5y0ie/5558nnU5zzz33FJml77vvvmnrPvbYY1x44YU4nc7CuCcmJtiwYQO5XI5XXnmlaP2bbroJp9NZeH3hhRcC0N3dfVJjPhZPPPEEoihy4403Fo2zoqKCxYsXF1wib775JmNjY3ziE59Ap9MVPn/bbbdht9uPuZ8lS5bQ2trKL37xi8KyXC7H448/zl/91V9hNBpn/ex8XT+Q40zy4xdFEb/fTzabZe3atcd0BR6NXC7HLbfcQiQSYevWrYXYqMceewy73c7ll19edH7z7oD8+T2ee+t4+cQnPlH0+sILL8Tn8xV+B46HydcpEAgQCoW48MILZzx3GzZsoLGxsfB61apV2Gy2wj2dy+V4/vnnufbaa4sCGpuamrjqqquOe2wzjTGTyeDz+WhqasLhcBSN8w9/+APr1q0rsqK5XC4+9KEPFW3vueeeIxgMcssttxRdQ7Vazbnnnjsnt+FkxsbG+OAHP8iiRYv4zGc+U1h+st+x4+FkvlPH+q0aHh5mz549fOQjHylyeV188cWsXLnyJEc+M5dffjmvv/4673//+9m9ezdf//rX2bhxI1VVVdPCBCbzuc99jmw2y1e/+tVj7uOhhx7iueeeK/r39NNPz+dhzMh71vVjs9kA2U95qrn44ou5/vrreeCBB/jGN77BJZdcwrXXXssHP/jBY2ZPdHZ2IkkSn//85/n85z8/4zpjY2NF5sSZorK//vWvc+utt1JTU0NbWxubNm3iIx/5CA0NDcd1LH19fQAsXry4aHlpaWnRFxfg8OHDvPXWW7OasKcGeNXW1ha9zm9vahzDfHP48GEkSZp2THnyptzZjl2r1c75PN5000384z/+I0NDQ1RVVfHSSy8xNjbGTTfddNTPzdf1y/OTn/yEf//3f+fgwYNF4nmme2eufO5zn+OPf/wjTz31VNHkfPjwYUKh0Ix+cjhyHxzPvXW8HO3eyv8WzJUnn3ySL33pS7S3t5NKpQrLZ4p7mrrf/L7z9/TY2BiJRGLGrImTyaRIJBI8+OCDbNmyhaGhISRJKrwXCoUK/9/X18e6deuOue/Dhw8DcNlll824v+M5h7FYjGuuuYZIJMKrr75aNJHPx3dsrpzMd+pYv1X545jtup7oA0Eul2N8fLxomcvlKoi6s88+myeeeIJ0Os3u3bvZunUr3/jGN7jhhhtob29n+fLl07bZ0NDA3/zN3/CDH/zgmNmQ55xzzhkJpn1PC5XKykr27t17wtuYrWhYLpebtt7jjz/Otm3b+N3vfsczzzzDRz/6Uf793/+dbdu2TQsym0w+6PRTn/oUGzdunHGdqV+GmZ7Mb7zxRi688EK2bt3Ks88+y7/+67/yta99jSeeeOKkntyOhiiKXH755UVPTJNZsmRJ0evZskkm/8ieCkRRRBAEnn766RnHcLTrc7zcdNNNfPazn+Wxxx7jvvvu45e//CV2u50rr7zyqJ+by/U72v04+bh+9rOfcdttt3Httdfy6U9/mrKyMtRqNQ8++CBdXV0ndFy//vWv+drXvsYXv/jFacciiiJlZWX8z//8z4yfPZlYjLkyX/fWn/70J97//vdz0UUX8fDDD+PxeNBqtWzZsoVHH330lO0X5v57A3DPPfewZcsW7rvvPtatW4fdbkcQBG6++eYTSrfNf+anP/1pUXxVnrlm0aXTaa677jreeustnnnmmTnHUsyV4zlHJ/ObeKZ+qwYGBqY9TLz44ovTAm11Oh1nn302Z599NkuWLOH222/nscce4wtf+MKM2/2nf/onfvrTn/K1r32Na6+99hSN/sR5zwoVgGuuuYYf/OAHvP766zM+VRyLvIoOBoNFkdZ5NT2V8847j/POO48vf/nLPProo3zoQx/i5z//OXfcccesX7C8utdqtSedwufxeLjrrru46667GBsbY82aNXz5y18+LqGSL5h2+PDhoieP8fHxaZaPxsZGotHovKYezndFWZDHKUkSixYtmiaeJjP52Cc/WWYyGXp6eli9evUx97Vo0SLOOeccfvGLX/DJT36SJ554gmuvvXZOdUmOdf2cTifBYHDa5/r6+oqu1eOPP05DQwNPPPFE0fmc7UfsWBw6dIhbb72Va6+9ln/8x3+c9n5jYyPPP/8869evP6p763jurTPFr371KwwGA88880zRNduyZcsJba+srAyDwUBnZ+e096Yum/x7M5mZfm8ef/xxbr31Vv793/+9sCyZTE77bF1d3Zz2nbeQlZWVnfD3WRRFPvKRj/DCCy/wy1/+spCVN3U8cOLfseM5RzA/v4kzkT+OuZzb2Zjpt66iooLnnnuuaNmxzkneAuL1emddp7GxkQ9/+MN8//vf59xzz53T+E4n79kYFYDPfOYzmM1m7rjjDkZHR6e939XVxbe+9a1ZP5//8k6OtYjFYvzkJz8pWi8QCExT2nmfcN50nI/Cn/oFKysr45JLLuH73//+jDfaVDPgTORyuSJzb367lZWVRabrubBhwwa0Wi3f+c53io5pagYPyE8sr7/+Os8888y094LBINls9rj2DRTiHmaakE+U6667DrVazQMPPDDtOkmShM/nA+QvfGlpKf/5n/9ZlIXy4x//+LjGc9NNN7Ft2zb+67/+i4mJiWO6feZ6/RobG9m2bVvR2J588slpKdb5p8HJx/rGG2/w+uuvz/kY8kSjUTZv3kxVVRU/+clPZvxxvfHGG8nlcnzxi1+c9l42my2cu+O5t84UarUaQRCKntB7e3v59a9/fcLb27BhA7/+9a+LYiU6Ozun+f5tNhslJSXTYrsefvjhGbc79V7+zne+M82ysHHjRl5//XXa29sLy/x+/zTr18aNG7HZbHzlK1+ZMc5uLr9D99xzD7/4xS94+OGHC5mNUznZ79hcz9F8/ibORGVlJS0tLfz3f/830Wi0sPzll19mz549c9qG2WyedswGg4ENGzYU/cuLsxdffHFGi87vf/97AJqbm4+6v8997nNkMhm+/vWvz2l8p5P3tEWlsbGRRx99lJtuuolly5YVVaZ97bXXeOyxx45aFfCKK66gtraWj33sY3z6059GrVbzX//1X5SWltLf319Y7yc/+QkPP/wwmzdvprGxkUgkwg9/+ENsNhubNm0CZHfN8uXL+cUvfsGSJUtwuVy0tLTQ0tLCQw89xAUXXMDKlSv5+Mc/TkNDA6Ojo7z++usMDg6ye/fuox5nJBKhurqaG264gdWrV2OxWHj++efZvn170RPXXCgtLeVTn/oUDz74INdccw2bNm1i165dPP3009PSDD/96U/z29/+lmuuuYbbbruNtrY2YrEYe/bs4fHHH6e3t3faZ45FW1sbAPfeey8bN25ErVYfNa13LjQ2NvKlL32Jz372s/T29nLttdditVrp6elh69at/J//83/41Kc+hVar5Utf+hJ33nknl112GTfddBM9PT1s2bLluPznN954I5/61Kf41Kc+hcvlOuYT6lyv3x133MHjjz/OlVdeyY033khXVxc/+9nPiuJFQLYkPvHEE2zevJmrr76anp4e/vM//5Ply5cX/ajOhQceeID9+/fzuc99jt/85jdF7zU2NrJu3Touvvhi7rzzTh588EHa29u54oor0Gq1HD58mMcee4xvfetb3HDDDcd1b50prr76av7jP/6DK6+8kg9+8IOMjY3x0EMP0dTUxFtvvXVC27z//vt59tlnWb9+PX/7t39LLpfju9/9Li0tLUUCAuRr/NWvfpU77riDtWvX8sorr3Do0KFp27zmmmv46U9/it1uZ/ny5bz++us8//zz09JIP/OZz/Czn/2Myy+/nHvuuaeQnlxbW4vf7y8IT5vNxve+9z3+5m/+hjVr1nDzzTcXfueeeuop1q9fz3e/+91Zj/Gb3/wmDz/8MOvWrcNkMvGzn/2s6P3NmzdjNpvn5Ts2l3M0n7+Js/GVr3yFv/7rv2b9+vXcfvvtBAKBwnWdy/esra2N733ve3zpS1+iqamJsrKyWWOEQBaC8XiczZs3s3Tp0sI89otf/IL6+npuv/32o+4vb1WZ+qA9maeffpqDBw9OW37++efPewxREac8r+gdwKFDh6SPf/zjUn19vaTT6SSr1SqtX79e+s53vlOUEjxT+ueOHTukc889V9LpdFJtba30H//xH9NSOHfu3CndcsstUm1traTX66WysjLpmmuukd58882ibb322mtSW1ubpNPppqXSdXV1SR/5yEekiooKSavVSlVVVdI111wjPf7444V18vudmgadSqWkT3/609Lq1aslq9Uqmc1mafXq1dLDDz98zHMzUzpqLpeTHnjgAcnj8UhGo1G65JJLpL179854fiKRiPTZz35WampqknQ6nVRSUiKdf/750r/9278V0ubyKX//+q//Om3/U89DNpuV7rnnHqm0tFQSBKEofXPqunNNT87zq1/9Srrgggsks9ksmc1maenSpdLdd98tdXR0FK338MMPS4sWLZL0er20du1a6ZVXXpmWAnws1q9fLwHSHXfcMeP7k4/leK7fv//7v0tVVVWSXq+X1q9fL7355pvTxiaKovSVr3xFqqurk/R6vXTWWWdJTz755IypuFPP6dT74dZbb501bXHqvfCDH/xAamtrk4xGo2S1WqWVK1dKn/nMZwppkZJ0fPfWsc6bJB251uPj40XrHSvNOs9M5+SRRx6RFi9eLOn1emnp0qXSli1bZryngBnTX2c6lhdeeEE666yzJJ1OJzU2Nko/+tGPpP/3//6fZDAYitaLx+PSxz72Mclut0tWq1W68cYbpbGxsWnHHQgEpNtvv10qKSmRLBaLtHHjRungwYMz7nvXrl3ShRdeKOn1eqm6ulp68MEHpW9/+9sSII2MjBSt++KLL0obN26U7Ha7ZDAYpMbGRum2226b9ls203mc7T6Z6TqczHdsLudort+p2dKT5/JbJUmS9POf/1xaunSppNfrpZaWFum3v/2tdP3110tLly495nGMjIxIV199tWS1WueUmv30009LH/3oR6WlS5dKFotF0ul0UlNTk3TPPfdIo6OjRetOTk+ezOHDhyW1Wn1c6cnMkg4+nwiSdIqjfxQUFBQUjptrr72Wffv2FTJuTif33Xcf3//+94lGowu6ZcI7kdbWVkpLS6fFmijMzns6RkVBQUFhITC1S/vhw4f5/e9/f1oalE7dt8/n46c//SkXXHCBIlJOgkwmMy0O76WXXmL37t0LqvHsOwHFoqKgoKBwhvF4PNx22200NDTQ19fH9773PVKpFLt27Zq1vs980drayiWXXMKyZcsYHR3lkUceYXh4mBdeeIGLLrrolO773Uxvby8bNmzgwx/+MJWVlRw8eJD//M//xG63s3fv3lNfdv5dxHs6mFZBQUFhIXDllVfyv//7v4yMjKDX61m3bh1f+cpXTrlIAdi0aROPP/44P/jBDxAEgTVr1vDII48oIuUkcTqdtLW18aMf/Yjx8XHMZjNXX301X/3qVxWRcpwoFhUFBQUFBQWFBYsSo6KgoKCgoKCwYFGEioKCgoKCgsKC5R0foyKKIsPDw1it1lNSXl1BQUFBQUFh/pEkiUgkQmVlJSrV7HaTd7xQGR4epqam5kwPQ0FBQUFBQeEEGBgYoLq6etb33/FCxWq1AvKBHm+7dgUFBQUFBYUzQzgcpqampjCPz8Y7XqhM7kWhCBUFBQUFBYV3FscK21CCaRUUFBQUFBQWLIpQUVBQUFBQUFiwKEJFQUFBQUFBYcGiCBUFBQUFBQWFBYsiVBQUFBQUFBQWLIpQUVBQUFBQUFiwKEJFQUFBQUFBYcGiCBUFBQUFBQWFBcs7vuCbgoKCgsL8kcvl2OHdwURighJjCW2eNtRq9ZkelsJ7GEWoKCgoKCgA8FzXc2zZtYUOfwepbAq9Rk+zq5nbz7qdyxsvP9PDU3iPoggVBQUFBQWe63qOB15+gEAiQJWtCovOQjQdZffobh54+QEARawonBGUGBUFBQWF9zi5XI4tu7YQSARYXrIcp8GJVqXFaXCyvGQ5gUSALbu2kMvlzvRQFd6DKEJFQUFB4T3ODu8OOvwdVNmqUKmKpwWVSkWVrYoOfwc7vDvO0AgV3ssoQkVBQUHhPc5EYoJUNoVFZ5nxfYvOQiqbYiIxcZpHpqCgxKgoKCgonHFEUaQr0EUoFcKut9PobJxm2TiVlBhL0Gv0RNNRnAbntPej6Sh6jZ4SY8lpG5OCQh5FqCgoKCicQdq97Ww9uJUOXwfJbBKDxkCzu5nNSzfT6mk9LWNo87TR7Gpm9+hu7Dp7kUgSRZGh8BCry1fT5mk7LeNRUJiM4vpRUFBQOEO0e9v59l++TftIOyWmEpaVLKPEVEL7yNvLve2nZRxqtZrbz7odp9HJ/on9BJIBMmKGQDLA/on9uIwubj/rdqWeisIZQbGoKCgoKJwBRFFk68Gt+OI+WkpbClYMp8GJXWdn7/heth7cyqryVafFDZRPPc7XURmODKPX6Fldvlqpo6JwRlGEioKCwrseUYSuLgiFwG6HxkY4jSEgM9IV6KLD10GNvWbGTJsaew0dvg66Al0sdi8+LWO6vPFyLqu/7JRUplUq3iqcKIpQUVBQeFfT3g5bt0JHBySTYDBAczNs3gytrWduXKFUiGQ2iVVnnfF9q87KYHiQUCp0WselVqs5p/qced3mfFW8VcTOexNFqCgoKLxraW+Hb38bfD6oqQGrFSIRefnAANx775kTK3a9HYPGQCQdmTHTJpKOYNAYsOvtZ2B088d8VbxVyvu/d1GCaRUUFN6ViKJsSfH5oKUFnE7QaOS/LS3y8q1b5fXOBI3ORprdzQyEBhCnDEIURQZCAzS7m2l0Np6ZAc4D81XxNi92do/uxm10s8S9BLfRXRA7z3U9d5qOSOFMoAgVBQWFdyVdXbK7p6ZmejyKSiUv7+iQ1zsTqFQqNi/djNvkZu/4XgLJAFkxSyAZYO/4XtwmN5uXbi6KX5EkCV/cx1B4CF/chyRJs25fFEUO+w7z5vCbHPYdniaGTgfzUfFWKe+voLh+FBQU3pWEQnJMinXmEBCsVhgclNc7U7R6Wrn3nHsLdVQGw4MYNAZaK1qn1VHxRrzs9O6kP9RPKpdCr9ZTa69ljWcNHqunaLsLoTYLzK3i7XBk+KgVb49H7Mx3bI3CwkARKgoKCu9K7HY5cDYSkd09U4lE5PftZzgEpNXTyqryVUetTOuNeHm682mCySAeiwejxkgim6DD18FobJSrmq4qiJV8bRZf3EeNvQarzkokHaF9pJ2B8AD3nnPvaRMr81Hxdj7EjsI7G8X1o6Cg8K6ksVHO7hkYmB6HIory8uZmeb0zjUqlYrF7MWsr17LYvXiau2endyfBZJAmZxMWnQW1So1FZ6HJ2UQwGWSndyeSJE2rzeI0ONGoNDgNTlpKW/DFfWw9uHXObqCTdR/lK94OhYdmjMMZCg/R7Go+asXbyWJnJpTy/u9+FIuKgoLCuxKVSk5BHhiAvXuLs34GBsDtlt8/0/VUjoU/4ac/1I/H4kEQBECO2+gMdBJJRdCoNPT4e/An/PgT/nmrzTIf7qN8xdsHXn6A/RP7i7J+hsJDc6p4q5T3V1CEioKCwruW1lY5BTlfR2VwUHb3tLae+ToqcyWZTZLKpTBqjADsGtnFC10vMBgdJJvNolFrcBgcuMwulriXzEttlvl0H51sxdv5EDsK72wUoaKgoHBS5HKwYwdMTEBJCbS1wUKaM1pbYdWqhVOZ9niLlhk0BvRqPYlsgsP+w/x8z8+JZqK4jC6MRiPRTJShyBDf2vYt/nbt3550bZZTUdr/ZCveKuX939soQkVBQeGEee452LJFtlakUqDXy3Eft98Oly+guUOlgsWnpwr9UTmRomUuo4taey37x/bzfNfzRDNRqi3VqNVqJElCrVLT6GgkmAzyh8N/oLmkmfbR9hndJH3BPuod9QQSAQ77Dk8L2oVTV9r/ZCvensry/goLG0WoKCgonBDPPQcPPACBAFRVgcUC0Sjs3i0vh4UlVs40J1qhVRAE1njWsG1wG93BbpwGJyqVioyYIZlNolPpcJvdmPVmDgcPc03zNQxEBtg7vrfIbbN3ZC+hdIh0Ls1XXv3KrDEnC7W0P5ya8v4KC58FHkamoKCwEMnlZEtKIADLl8vpv1qt/Hf5cnn5li3yegonX7TMY/XQ7G5GLahRC2pimRiZXAar3kqFpQKVoEItqImn4ziNTjmGpKKVifgEByYO0OnrJJgKYtfbWexezLKSZZSYSmgfkWNR2r3thX1NLu0/E5PdRwuhqJzCux/FoqKgoHDc7Nghu3uqqmau+lpVJb+/YwecozwAz0vRsiXuJZSYS7Bqrdj0NlQqFaIoEkgFiKfjRFNRErkEHRMdrPGs4QsXf4GuQBfBRJCf7P4JWpW2KK5ktpiTfGn/9pGZ3UcDoQFaK1qJJCM88PIDZ7yonMK7H8WioqCgcNxMTMgxKZaZa3BhscjvTyg1uIC5FS1LZVNHLVqWT9Mdj4+jV+sRJZGR6AiRVES2puTiVFuryYk5nu58mtHYKIvdi3EYHUwkJqhz1h0z5iS/7Fil/ZeVLOO7b36X9pF2SkwlR7XQKCicLIpQUVBQOG5KSuTA2ejMNbiIRuX3S85gDa6F5JaYj6Jl+TRdp9HJ/vH9DIQGSGQSSEiMxEaw6qxcufhKmkuai4rAzSXmJJlNFsWc5Ev7T3YfTcQnaK1o5ZNnf5IDEwfmrajc8fQvUnhvorh+FBQUjpu2Njm7Z/duOd138oO6KMLQEKxeLa93JlgovW7ynGjRMkmS8Cf8hWPY0LABgP/c/p9s925HlET0Gj2L7It4X+P7OKviLAA8Fg/9oX78CX9RzMnxpCzPVtp/PrOCjqd/kcJ7F0WoKCgoHDdqtZyC/MADsH9/cdbP0BC4XPL7ZyJz9Ez1upkqKlxGV6GS7IkULTvaJP6Njd/gG298A4vGgt1op8nZVEhXjqQjJDNJfAkfiUyiKObEprWRElNkxSwalQa9Sl+IOWl0Tu8loFKpaHI1FY4rkAwQTAbnJSvoePoXKby3UYSKgoLCCZFPPc7XURkelt09q1efuToqp6JY2VyYi2XgeIqWzTaJ7x/fz7aBbVRZq9CqtDSXNGM3ypYQf8JPV6CL8dg40XSUjJjhT/1/4pL6S9i8dDMdvg5e6H0Bg8aAVqUtpDcvci5i89LNqFSqacXoKi2V7B7bXXRcauGIIDrRonK5XI4nO55k38Q+lrqXYtKaUAmqQv+izkAnO7072WTZVBB7Cu9dFKGioKBwwlx+OVx22cKpTHuqipUdjZlERSwd49X+V3lj8A02Nm1kXfU6VCrVnIqWTW1CmJ+oD/sP83zX83QHu1ELarQqLc93Pc9fL/tr6h317PDuIJqKYtAYSOVSlJvKGQoP8XTn06ypWMNS91L8cT+RTIRkNolKpcKut7PUvZRyS/m0YnQqQYVRY6S1opVL6i8piKWh8BBIcNh3mLWetbNmBc1koQHZ4vU/e/6HP/b+EQGBHd4dVFmrOK/qPErNpWRyGSxaC32hPvwJP26Te16uk8I7F0WoKCgonBRq9cJJQT7dxcpmEhXdgW7eGHiDgcgAgWSAl/pe4tL6SwvxMccqWuZP+OkL9mHRWvAn/GjVWjr9nfxi3y+IpqI4DU7UKjUmtYm+cB8/bv8xayvXohJUpHNpRqOjaNQaDBoD4VSYSDpCX7APm97GXWffxWhslFgmhllrptxcTnewm0d2PlIQW1W2KsxaM73BXnpDvYRTYapsVZxVcRYWnYUl7iUMR4d5a+Qt9oztodZRW3CvDYQGcJvcBQvNVPJuucHQICaNiVJzKalcio6JDg6OH2SxezF2gx21oEaURM6rOm9WoXI0V5vCuwtFqCgoKLxrONHA0RNlamfj7kA3v+v4HeF0mFJTKQ6jg3AizBuDb8w5PqYv2Ef7aDsCAjkxh1ql5s/9fyaUCFHvqEcQBGKZGG6zG5fJxa6RXbw28Bo1thpUgooKSwXV9mp0Kh1DkSGyYpZgMsjVi69GrVJTaa0s2l+ZqYxv7fkW4VSYVWWySyxvUam31eONenmh+wVWla1CrVIjCAJnV56NXqMnl8vRH+5nMDyIQWOgtaJ11oDlyW65FaUrOOg7KLcAENSoVWrGomMMhYdocjYRyUTwRr28OvAqHqtnWqyKEoT73uK0pSd/9atfRRAE7rvvvsKyZDLJ3XffjdvtxmKxcP311zM6Onq6hqSgoPAuIx84OhAaQBRFREnEn/AzHBlmIjZBX7CPZnfzrG6J42VyZ2NRFHlj4A3C6TB1tjosOgtGtRG9Vs8S15I5pe16I15e7X8VX9yHVq2l3FJONB3FG/WiVqnJSllyUq5QidasM9PgaCCRSWDRWTiv+jyWly7Hrrdj1BrxWDwkMglGY6OoZvm5H44M4416KbeUF6wgOSmHKIlo1VrcJjeDkcFCnRUAo8ZIubmce865hy9e+kU+d9Hn+OKlX+QLF39hViE22S1n1pmx6+1E0hH8CT9ZMUuppZRgKkgwGSSRSbCiZAWZXKaQZj35HD3d+TQdvg4cBgf19nocBgcdvg6e7nwab8R7AldSYSFzWiwq27dv5/vf/z6rVq0qWv53f/d3PPXUUzz22GPY7XY++clPct111/HnP//5dAxLQUHhXUa+WNlAeIA/9/+ZWDZGNB0lmU2SzqUpM5fxoZUfmrdA2smdjUPJEAPRAUpNpYXtZ8SMHE+i0R4zPibvRsqIGZaXLmc4MoxD7yAn5RAQEASBSCqCVqXFZrChU+vkMWgN5KQcRo0Rs85ctE1BELDqrWTEDOF0mHLKp+13Ij6BKIpY9UfcZWpBjUpQkZNyGDQG/Ak/4VS48H4im0Cv1mPSmagx1czpXOXdcmpBTTQdxW6w40/4mYhNYNFb0ApaQtkQw5Fh6p31NLoa0al19AX7OOw7TDqXRpIk9oztIZAIsNi1uODqUYJw392ccqESjUb50Ic+xA9/+EO+9KUvFZaHQiEeeeQRHn30US677DIAtmzZwrJly9i2bRvnnXfejNtLpVKkUqnC63A4PON6CgoK701aPa1c0XAFXx3+KmPxMQwaA0aNkVJTKSatiWe7n2VpydJ5SVHOdzbu8HWACJlsBqPJCMjCI5qO4ja5MWqM6NS6o8bH5N1IldZKSkwlhFIh2ZIiqNGoNYiSSDgVpsxchtPgLEzEqWwKrVqLhIQkSUUTtCRJ5KQcJcYSgsngtPdFUSSUDKHVaImlYpg1ZgRBQKfWYdKaiKTkfj8atQab3lbYpjfqpdndjMvomvO5SmVTBBIBAomAnD2kUiMgoFFp5HFkQ0iCRLW9mjWeNbiMLsZj47w68CpvDL1BLBMjlU0RSoVoKW2hxFRStH9BEIrqxyhBuO8eTrnr5+677+bqq69mw4YNRct37NhBJpMpWr506VJqa2t5/fXXZ93egw8+iN1uL/yrqZmbmldQUHhvIIoiByYOUGOr4f2L38+l9ZdySf0lXN5wOetr1h935dSjke9s7DA4GE+My/EjWXlCHY2NIiEV4mGOFR8z2Y3kMrpo87RRZavCqrNi1ppla8rbrhij1lg41tHYKFXWKjwWD96ol0Q2gSiJJLIJvFEverWetso2SswldAY6iaaj5MQcA6EBfnfod0QzUWxaGx2+DobDwySyCQRBKFSc9ca8lJvLqbfXE01H6Qx04jQ4WeNZM2erhTfi5eD4QQxqA5FUBJvehkFjIJlLAnJskU6jo7W0lcsXXY7L6MKf8PNiz4t0THQQz8SptddSYakglo7x1uhbvNL7Cv6Ev2g/Ro2RVC5FMps80UuqsAA5pRaVn//85+zcuZPt27dPe29kZASdTofD4ShaXl5ezsjIyKzb/OxnP8vf//3fF16Hw2FFrCgoKBTIx0LUOetmDKid7xRlj9XDVU1XUWos5a3RtzjsP4xFY0FQC1iw0B/qJ5gIEkwFOa/6vFnjYya7kSw6Cy6jC6fBSSQdwaK3sPXAVrlrspghI2YKxeJKTaVc2XQlGSmDKIpMxCcIikG0Ki2V1kpUKhXnVJ7DWRVnsWtkF/2hfg7FDtHp70Sv0bO+Zj2LXYt5dO+jHA4epiRVQp2jjqyYJZwOU2KQU6gHIgPo1Xqa3c2FoNWpdVemplrDEZdWKB3iqsVX8eShJ+kOdOM0OLHqrIzFxugKdrHEtYSLFl1UKFzX6evkkP8QLoOLJe4lqAQVAgKlplKS2SQD4QG6fF04q45Yl/IuKYPGMKdrp2QOvTM4ZUJlYGCA//t//y/PPfccBsPcbpq5oNfr0ev187Y9BQWFdxenO0UZZLFyTfM1pHNpvvbnrxFKhagz12HRy9Vn947vxWl0ckHtBbPGx0x2I+VTnQVBwKa3cVHtRURSEQ5OHCScCjMRnygqFtdS1sLTnU8TSASosdWgFtTkpByRdASX0VUQFh6rB1/cx1OHn0IlqFhZupJYNoZJa+K6pdfxav+r9IZ62Te2jxJTCWs9a7mt9TbaKtumTeZT667oNXqaXc3TitdNzoxK59I0OBsIpUL0hHoQJRG1oMakNbGkZAll5jJyYo6x2Bjto+1oVVqaXE2oBPmcGTVGHEYHI5ERRElkIDJAc7oZm952XC4pSZLYP76fHcM7GI2NolHJ6dxK5tDC5JQJlR07djA2NsaaNWsKy3K5HK+88grf/e53eeaZZ0in0wSDwSKryujoKBUVFadqWAoKCu9yTneK8mQMWgMX1l7IYGSQ4egw4UgYrVpLS1kL1dbqQkDoTE/teTfSaGyUzkBnUUVab9TLedXn8fkLP89wdHhGC8ZVTVcVUnbj2Th6tZ6lJUuLJt68+Iln4riNbnaN7GIsPkYml0Gr1nJJ/SWkxTSxdIxrm6/lskWXTbOQADzX9RwPvPwAgUSgqB3A7tHdPPDyA8CRSrx5l1Yik6B9tJ2clOOi2ouIZWLE0jFimRhZMUuzW26mOJobJZFJFFxeLlNxHEqFpYJIKsJ4bJxwKkwyk0QlqPBGvXNySXkjXp7reo4nDz1JMBmkxFTCIsciHEYHfxn6C13+Lm5YfgOVtspZt6FwejllQuV973sfe/bsKVp2++23s3TpUv6//+//o6amBq1WywsvvMD1118PQEdHB/39/axbt+5UDUtBQeFdzuTeNjM1ADxW5dQTJW85WFu1lou0FzESHSkUVquwVBDPxI8Z6Jl3I+UFx2hudJq7pdpRPetnN1k2HdOVkcwmGYuPMRGbIJ6J4zQ40Rv1pLIpvFEvJq2JMksZy8uWzyhScrkcW3ZtIZAIsLxk+bQ2Bfsn9rNl1xYuq5dFjkFjQKfWcWDiALF0rFBzxqSTC77FM3F6Q72Umkq5ovEKUrkU8UwcjaDhwMSBQtxOHqvOSo29hlQuhSiJjMRGcImuonM0G96Il0f3PMqzXc/iT/gxaU10+jt5a/QtjFojldZKclIOX8LHnW13KmJlgXDKhIrVaqWlpaVomdlsxu12F5Z/7GMf4+///u9xuVzYbDbuuece1q1bN2vGj4KCgsKxmJyivHd8b1FjwmNVTj0ZJgfDqgQVHouHSDpCIBFgIDSATW8jmU0eM9BzroJjJgRBOGa2i16tZyw6RjARpNxSTkbMIGbkwGKL1sJwZJiclEOvntnFvsO7gw5/B1W2qhnbFFTZqujwd7DDu4Nzqs8pxNq8EHihULAujyRJBJNBGh2NBJNBBEGgylaFJEksK1tGh68Df9yPx+IhkAyQzqXRqrSksinq7HW8b9H7uKjuIoxa47RzNDX+xGlw8nz384U6NYIg4Ev4mIhPkMgkEBAIp8JUmCt4rus5NCoNd6y5Q3EDLQDOaGXab3zjG6hUKq6//npSqRQbN27k4YcfPpNDUlBQeBfQ6mnl3nPuZevBrXT4OuZUOfVkmRwMm86laR9pZ8/oHnwJHwA2nY16Zz1XNF5Bla3qqNuai+A4GaLpKMORYbnDcjZBNBMFCcxaM8lskng2zkh0hBJzybTPTiQmSGVTWHSWGbdt0cliZyIxUTiWZnczWrUWf8KPgIBeoyeZTTISHcGgMVBtrcaf8NMT7AEoZD0d8h3imc5n2D68nXQ2TVbKkhWzWHVWrmy6kksXXTqjkJipcq1db+eF7hdIZVPEMjG0Ki2JbIKMmJGbNEoZ/HE/lZZKsmKWvwz9hXpHPR9e9WElwPYMc1qFyksvvVT02mAw8NBDD/HQQw+dzmEovEsRRejqglAI7HZobIR5fmhWeAfR6mllVfkqugJdhFIh7Ho7jc7Gebek5HEanDgMDv4y/Bd6/b3sHd9LLBMDSX66HxAH8Ea9/HLvL/nE2Z+Y9yf1uWaw9If6CSaDZKQMyXSSRFqerEVJJJFJUGoqJSfmeKbrGdwm97RxlhhL0Gv0RNPRGWOAoukoeo2eEuMRkVPnqKO1vBV/wk8kHWE4MkwoKddN0av0/O7w70jlUkTSEeod9YWg1pVlK9l6cCuRVAS1Si61b9QY0aq1DEQGGI2OFo0vHyT7h84/EM/EaXQ2YtKaSGQT7PTuZM/YHux6O5IkoVVpiaVjqFBh0BrQiTpimRj+hB+P1YNBbeD1wde5qumqGQWbwulD6fWj8K6gvR22boWODkgmwWCA5mbYvBlaW8/06BTOFCqVat66JB+N/BN8b7CX1/tfp8PXgSiKmLVmjDojGTGDKqcikU3wTNczNLma+PDq+XtSn2vvG0mS6PB1oFFpWFGygv2+/SRzSYwaIwICkiRh0puos9YRz8RnrPLa5mmj2dXM7tHdM8YADYWHWF2+mjZPW2G5y+hiZflKDk4cpFZdy07vTgSjgEVnYSA8gD/hx6q3EkvHCmP0RrwcmDiAU++kbWkb8WwcQRIw68wYNAb2je9j68GtrCqX+xN5I152eHfw+8O/ZygyRKW5kmwuS4OrAZfRRY2tRrag5DI4jA4CiQCZXAa95oiLSyWoiKQjNGgbqLZXMxAemNWypHD6UISKwjue9nb49rfB54OaGrBaIRKRlw8MwL33KmJF4dSR7z0TTAZxG91oVBokJERE0lIarajFqrViNpuJZ+L4Ej5e7H2RqxZPf1IXRfG4LUCT9z85U6jD18FobJQrG68suFrimTj+hJ8GZwPDkWHMGjM2p00uma9SgQRjsTGsJVYanY2F4F+X0YUv7mMkKte4um7pdfSH+tk/sb8o62coPITL6OL2s24vCsTNZzSNREd4ffB10rk0tTY5FdsX91FpraTB2UA0HWU0Osoazxq2DW1j+/B2VpWtwqq3FpX4h+J6OBadhac7n2YoPEQyk5TPGyoGI4MEkgHaKttwGV24jW56Q71UWCqIpuTCd5IkISGRyqVQoUKr1lJiLFHcPQsIRagovKMRRdmS4vNBS8sRV4/TKbt/9u6V31+1SnEDKcw/+WJmwWSQJmcT/aF+opkoJrUJg8FAVsxiUBtwGByoVCpUgopUPMVgZHDak3q7t70QU5N33zS7m48aUzN1/1N73+zw7uCb276JwyD3DEplU/QEe1jqXopP7SOQDFBhrUCv0hf6AWnUGqpsVZi0JsbiY/QF+/j94d/z+uDrjMXGADneZmX5SvpCfYzGRhmODBfVdZlcRyWPx+rhvOrz2OHdgSiKDEYGGU+MU2WtotZRi1VnRavSMhYfI5qJYtFZCCVDqFXTM4/gSD2cYDLIId8hgskg1dZq+kJ9hYBmg8aAN+ql29/NGs8alpcupyfYI7cisJThS/jk4GYJEMBtdOOxeLDqrYxFxyg3l1NhUcplnGkUoaLwjqarS3b31NRMFyIqlby8o0Neb/Gp9wC8Z5Ek8PuPuN1cLngvPJBOLmZW9AQugFatRavWkhXf7niMCgm5C/DkbsAgi5Rv/+Xb+OK+oiyl9pF2BsID3HvOvTOKlVn3D/QEe9g2uI2hyBAVlgokSSIrZhmPjdMf6meRYxFmrZlgQu4BpFVrselsWA1WSs2lJLIJkpkkTx1+ir1je9GqtLgNbkZjo+wd30sml6HeVs81i69hsWsxS9xLZqxMOxmHwcFi12LcRjcTiQkkJGpttQUxotfo5fiZXAanwYlKUBFOhgt9hiaTr4cjSVLhHIiSKGcFvZ19lW8FkBc/q8pXsWdsD8lMErNklt+LjaFWq3EanLiNblxGF4FkgKyU5bzq894xPYPezVV2FaGi8I4mFJInR+vMRUixWmFwUF7v3cZCEQdeL+zcCf39kEqBXg+1tbBmDXje5Zmdk1OSAZxGJyXGEsaiYySzSUwak+wGkkS5SWEqiqCSU3B1ah1D4SF0Kh1bD27FF/fRUtoyrS7JnrE9PLrnUdxGNyadqWgCmrr/PPnqsz2BHnK5HN2ZbhBBrVKjUWnwxeVMpFQ2RSqXKhS/i2aiLHIuwqK10BnoJJFNMBgexKw1Y9Pb6Ap0kcwmqbRUEklHCKaCDIYGqbPXUWOvOapIATkzyqAxoFVrKTeXY9VZSYtpjCpjYTxatRaNSoMKFS6ji/5wPx6rp8iyMrkejsfiKUoLLzWXMhQewmAxIAhCQfyks2lSuRS3tNzCYd9heoI9LHIuwqwzk8wkUatk95dOrUOtUnNu1blsaNiw4Cf7fADxm8NvyqLr7arEZeYy1lauZXnp8gV/DMdCESoKp49cDnbsgIkJKCmBtjY4xg/bsbDb5Uk6EpHdPQUkCRIJIv4cBpUWu00PvLO/rJNZKOLA64Wnn4ZgUN6v0QiJBBw8KFuxLrgA6urevRaWqf15rDorq8pX0R/uJ5QMIUoiGkFDVsoSS8aIZ+M4DA65pkfP86RzaYKJIC/2vkiTo2laPEosG0OURF7ofQGtWku1rbooSDa//3gmjoRUqDD7xuAbdPm7ECS5SaIkyZ2VM2IGERG9Wo8v4cNusGPWmkGSRY8gCIzHxtk1ugu30V0QWC6ji8HwIMlsstC5WRAEIukIOSnHUGSoKPB2tqf7yW0CGh2NRaICIJAMYNPb6JjoYL9vP3a9HW/Eyws9L7CiZAXl1vJp9XBMOlPRNWh0yjVZvFEvTqMTURIRkV1N1bZqrmy6EkmSeLnvZXqDvQSTQULJEBlRDrKtMFewrGQZbZVtC7qGSl6gPN/9PH/u/3OxYBXkvkfPdz/PFY1XsKFhw4I+lmOhCBWF08Nzz8GWLbIfJj+zNjfD7bfD5dP92ccib00wGI64d+z2t90/kQiMeBEDYQYGHbTW+2nsGAfru+MRfzZx0NEBo6Nw1VWn5zBFEV56Cfr6ZLea2Swv9/vlIObDh+Evf4Hly2HRIrj4Yqh8lxX6nKk/z+qK1XijXt4cfpNAIoBOrSOSiCCoBRwGB7X2WmwGG06DE6PGyL70PvwJP16dF5vRVuhRFElH6PJ3Ec/EAXDq5fTnfJDsVU1XUWGpwKKz8MeeP6JRyYIol8uxY2QHyWwSSZIKRdJUKhVGtZFkJkkik0Cr1iKJsrVHp9WhV+ux6W3Es3EkSeL8mvP5XcfvQICclCOUCmHRWQpP5xqVBgGBVC6Fy+AqBN6mc+lCBlIymyQrZoue7vNtArqCXVSYK/An/PQGewHQqXVMxCfoTnVTYang3KpzGY2O8lLvS+wd38twbBiHwVFUD0eSpKJrkK/B0hXoYiw6hjfqpdpWzVkVZxWJj5tbbi6IqXxxu1Qu9Y5wm3gjXp7vfp5nu57lsO8woiTiMDgYi42RyqYoMZZQ56zDF/fxTOczpLNpNi3Z9I4VK4pQUTj1PPccPPAABAJQVQUWC0SjsHu3vBxmFSszGWHGxoqtCVqtPFFv3w41JVEM3j6S8RzjmXJKPFk2XzCB6nAHjJ/GWfwUIUny+RgagupqWSyoVPIpbWqCzk753GzadGotGF6vLFJ+8xv5/I+NyYIpGoV9+2RXmyhCT4/8/zt2wLZtsi5diBlYJ5JtIyNQr2vjYDjC7tAgjZVO7Ho7F9ZeiIBAf6i/4E6osdXg0DuwGW20VbQVJkK30Y3T4CScDDMSHcHilAupjURHZIuE1kBGymDRWwpBsp2BTnZ6d3JWxVmMx8eJZCJoBS1lljImYhNMxCeIZWLoVLIbA0EWAQB6rZ5EIoFNb6PEVIJOo+P9S96P2+Qmk8uQzsmF1Wx6G2adbG1JZBLkxBxalbZw5Fkxi4SEQWPAqrfiT/rpC/bRPtpOMBnEoDbgi/sYjg7z6sCrRU/3k9sElJpKESURJAinwyQyCVaVr6LJJYuOUnMpy0qW8cbwG5Sby9m0eJPcqPDt6zNTjyS73s5S91K0Ki1L3EvY2LRxmgvkVBfVO1V4I95CcHMinUAtqElkE+wZ20NOyuHUOwkmg4zER3AZXYzHx3mx90V0Gt07tnidIlQUTi25nGxJCQTkR+upaTn798vvX3bZNDfQTEaY2lpoaJD1Tt6aUF4uZ/20t0uMHMoiJsvQm7U0V0e55SIvrS05kE7jLH4K2b9ftqYkErIlI5cDh0MubldbK5+T/n7ZquE+Rb/BeYtOX58sUqqr5cv76qswMiKLqWxWHpsoyiJq2TJZtPz4x/CZzywsy8qJZNvAZPdbBdHQVYwm+xlx9FPWNERZucAHV32Qent9YX2dWsfzPc8XXCd5PBYPNdYaDvoOEogHSFgTAISSIUxaE96olyZHEx7LkcaCHouHvmAf4VQYgKsar6In0MNYfIxYOoZG0KBGjUpQkRWzRfEd+UBelUqFRWshKSXRqXWFgNWcmKM31ItRY2RZ6TI6JjoIp8KoBTUZMYNOrUOSJCLpCCpUVNuq0ag06FS6Qsn7nJjjjcE3yIk5am21VJgr6A/183Lvy2RyGa5afBWbFm8qsmj4E35+deBXuI1uKiwVRedIrVazqnyVnAJuck8TkbP1SFrjWfOu6oacz/IajgyTzqbxJXx0BbsASGVSSILEWHwMjaAhlUtRZi5DQG5C+WzXs6zxrGFF2YozfBTHjyJUFE4tO3bISqOqaua0nKoq+f0dO+CccwpvzWSEiUTk1drb4bbbZAtCJALj4/KkWGpPUa4apNqTJS6ZEEXY329hRW2USnfq9MzipxCvF555Rg4OLi+XXT9+v2zB2L5ddq80NUmkcnG6x8Jg1M27CVuS5Mk5GJTdPWNjkE7LYwsGZYsKyAJFFCGTkS9vOAxLl8ruoJdfhptvXhha8USzbaa63zweO/F4C139izD3ZbhomcTyhmJBMhQeIp1LTwt8FQSBlvIW+sP99IZ68Vg8mPVmIqkIKVEOdD235lxUKhWSJBFOhZmIT9Dl78Kmt7GibAVWvRWX0UUkHcGf8DMeH6c70I0oyrVcsrksKkGuk5LKptCoNBjUBhJiArPGXNTXJ5FNoFfrMWqNhTL22wa3kczJdVgcRgehVIicmKPZ3Uyjs5GR2Agei4e3Rt+iY6KDQ75DRFIRzDozY7ExmkuaqbDKtUsK8SyLNxVZNFK5FEatUZ5cZ7g5jBojo7nRWXslnUyPpHcK+SwvtaCmJ9iDP+EvCM9UNkVGyiBJEnq1nqSYpCfQQ629llp7LT3BHnYM73hHBtcqQkXh1DIxIZtDLDP3BcFigeFheb23mc0IYzbL+mJ8XJ4kMhnZktLVJU+Qdr3IwREHfXEN8ZRson69Q6LPZ+RTf91DpSMnB3Ekj94UbiGSFwixGNhssjVDFGWLBkB3NxzsyKLWJTE6wxxK7GftZUOsbCyZ1ydKv1/Weh6PfD1KS2VD1eCgfN0kSb7cGo08PoNBXjYxIU/uKhW89RZcccWZ14qiKB4122bv+N6iyqd5Jou1pqYjgstqFVi93EJnJ/QehOUNxfubGngL8sTT7e9mLD6G3WAnmAzS4e/AqDWSyCWot9VzUf1FNDgb8Cf8tI+00+HrKHQ+NmlNRLNR1lSswWV0YdPLMS4rSlcwFBkilU1hFIyFjsQIcuaPVW8t9Lgpt5aj0+jePjYJb9RLs7u5MMnf0nILpaZSnu9+nr3jewkEA5Sby1ldsZpmVzP+pB+nwYmExAs9L5DJZZCQKLeUIyJ3Nw6lQpxdeTYIFMWzTBYqM50fURTxRr0kMgkkJPQaPQaNYdZr+k5158yVfFPLifgEyVwSURIRBNliIgkSiMgxReQQRAF/0l9ohuk2yqnlR+vevVBRhIrCqaWkRPbZRKNT0nLeJhqV3y85UvhqNiNMLif/tdtlcVJWJgfSCoLsAurq0REYc1FLjOqyFAIwEdbz8lslOM1Z7jj/IB69Xp4932HkBUJDg2xBCQbl4x8YkMVaTsyQFZJkMjl0KQPDe5ayDyfJ7JuFwMv5ECvJpCxEjEb5vDc2ytfC55NfS9KR62QwHBEq8bjsrjKZZFGTSJz0UE6arkAXHb4Oauw1BWtFIivHYqhVampsRyqfTi7DP1msTX0wFYTZDXdTA28DyQA7hncQy8RwGByUmctYVrIMjVp2o1h1VgRBoN5eT1+oj1f7X6U30CtbOzRG3CY3voSPNwbeIJqKclHdRQVxcW71uRwYP0BXoAuz1owKFYIgkJNyWLQWjDojerUerUpLhbkCk8ZENB2VM2UMTtZ41hSyd3RqHZfWX8q5VecyEBqgw9dBNB1Fq9YWGg62lrfyrTe+RSKboNJcyVh8DJ1aJ6cHq/SMJ8bZN76vUGXWn/RPs4xMPT/5OjCDkUHS2TTpXJplJcs4v/r8d9xEO18YNHIRwWAyiNvgZig8hEalkV09YgoEUEnyvSwKImrUaFVaugPdnFN9DhqV5pjduxciilBROLW0tcnZPbt3T0rLeRtRlKNCV6+W13ub2YwwKpU8CcbjsrvBaJQtCqIor5/MqkGjQiOm0WskBJWAx5Wkb9zIgT4LO/QSV2+uBacLv+/M1x85HvICIZeTdZ3DIYsU+VxJZHJZkikNRpMagTRiVmC01019w2oC7tdm7NlyIhgM8v4TCfn6uFyy1Wv7dtnaIwjy9TAa5XXVannMKpXs/qmokC1hC0GohFIhktlkwd0zEh0hlAyRk3KoBTVmnZloKkooVVyEZ7JYmwmj8YjhbmqQbmt5K6OxUQ77DzMaHSWSjuAyuggmg9j0crVXp8FJZ6CTUlMpY7Exfnvot/SH+ukL9SGJEma9mTJTGc3uZrwRLz2hHvpD/XT6Ozm78uzCNXaYHDiSDlK5FIJKQKfSUW4ux6w34zK6qLRUIgly6nFfuA+9Wk+zu5k1njVUWCrYN7aPHcM7GI2Nyq4ijYFaey3XLr22UJI/717p9HfSH+6nzlZXiF3JSlm0gpxtZNPZGI2OovFo0Kg06NXTLSOTg2Jf6nuJHcM7iGfjOA1OtIIWi9aCL+HjO9u/M6tL7t2Oy+iizFzGqwOvUmouBUCURFQqFXqNnKaeI4cWLUaNEY1anuIzYga73l6oY/NOQxEqCqcWtVpO9XjgATkSdHLWz9CQPNPdfntRIO1MRphEQn5CzcekCILsGnI65Sf2QACyWQGHU01G0pEOBdBb9GQlDTZtEiEa4UCkmkWWenqfFs54/ZHjJS8QIhFZnNXWykIlGgUEkSwieoOAzZUik9IQCevQ6iUGe6zUtNTNaGo/EVwued8dHUfcHnV18mXt6ZG1aDZ7RPjlXUGCADqdfAw22+yT/Okk/8M9GhllPDFOMpvEorOgVWnJiBm8ES+ZXIZUNlX0ualibSqJhPz+4eAefnDo8WlBuhfUXoBRY2T78Ha0Ki3xTJwqWxWNzkZcRhcgB9j2hnrJ5rKksimCySCSKLs+BAS5wq0AHpuHYCpIIBGgy9/FYtdioukoL/e/jF6t55aWW5hITLBvbB9d/i6GokO4RTcmrQmbwca1zddS66gtEh0j0RF+9tbPeLbrWcKpMG6jm0pbJZWWyqLU6CpbVeGY86Kv3lFPb6iXcCpMNBXFbrCTk3Kkc2kEQaDEWMJIbKTgWpqKx+phY8NGnu96Hn/ST4WpArWgxmV2UWGtwKwxz+qSey8gCAJrK9fyfPfzxNIx7Do7kXQEURRRC+qCCNEIGrQqLRpBQ5m5DKveSjQdZXnp8hnP+0JHESoKp5586nE+hWd4WP4lX716xjoqU40wqZScTZJOy64DUZT/plLyZJ3Lya4QtRocpVqycRs5UxYpHSUaBZc1hd5lZsRZwzM75RoVZ7L+yImQFwg7dx6J/xAE+TQaTSKhRBaLGQwGEY06CyJEA1oSMTXqnJl4LjUvJl9BkEXd6Kgcm5KPVamvh0OH5Em8pOSIqyePwyFXCXa5ZPfVQhAqjc5Gmt3N/KHzD1i0Ftwm95EaIYKGjJjBaXTij8sBi/n3ZhJreSRJjsXRlnbxk8PfwJ+YOUj3puU30VLWgsfswaA1FNw8eQxqA93+biqtlVxWfxmJTKIgJPRqPYFkgJHICE2uJppLmjkwfoBQKkSXv4uJxARWrZULai+Q3UNxH9F0FIfeQTKbpM5Rx4rSFUQzUXaN7qLcUo5erccb8bJ7ZDdvjb7FnrE9SJLEitIVpMU03oiXcCrMmoo1+JP+aRa6vOhDgCZXE2pBTXegm/H4OEaNEZ1Gh1atJS2mi1xLMxHPxhElkXMqz8Gqs6JWqQvl8KG4GeHp6Iy90FheupwrGq/gmc5nCrFGqVwKi86CSWMikAwgIuLQOygxlVBuLieYClJiKjnqeV/IKEJF4fRw+eVyCvIcK9Oef76c3fPmm0fK4wuCLEjMZonFDWlMKpGJEQ06kwa7XSCRkN0KKr0esbSCQDSNwZ3DVQ1pjASzAo6YrI/y39XTXX/kRJksEPr65GybTEa2rmSzAhqtiM6YI53SYrRkMJqzRMM6BBXk1LEZTe0niscji7rJtWyWLJENZOPjsogCWUSl07KQcTrlLKH6eli5Up7sj5f5bhmgUqm4tP5Snu16lkAygEFrKHQeHo+PY9PbuKTuEgYjg0XWqJnEWl70er3gcIjsNT6BPzF7kO7zPc9T76jHpDMVAkcnMx4fJ5KOUGWtQq/VYzPYCKVCqAQ51sSisxBKhUhkE+hUco2WWnstGxo28Prg61RZq7DqrUiSRHewm5yYY7F7MclsklgmhkVvwWP1sHNkJ//22r8VSuUPhgfJ5DI4DA5WlK2QRYLKiMHydnO/YDdL3UunWejyoq99pJ2W0hZWlq3EY/HgjXqJpCKMxkapd9RzfvX5rK1ae9R4qVAqRDKXZJF5ERrV9Ckq34xwqkvuvYIgCGxo2EA6mwbAl/Dhj/vxJ/xkpAw2vQ273k6OHCadiWAqSEtZC9cvu/4dm6atCBWF04daXZSCPBOTa6fE47IwGRmRJzu7HRqqE9SaJtAnozjEGHGTgaTexoo2F9v2WAruoFxOwO3RU14uu0vSaVnwNDYeXwDkQiIvELRauSP0kZgVNXoTJFI5LAYVZmuGVEKNKEJZZYyIuo+l9plN7Sczlk2bioXDlVfKdVL275etPiCfS4NBvib19fK/NWvmJjAmC5NgUHYtDQzMr8tusXsx62vXMxgaZCg6hC/uQ6vR0uRo4tyac6mz19Eb6p1mjZoq1kZHjxRbdtT38uyBHYUg3cmoVCpq7DX0h/pZ4loi10iZ1PVYPm6JocgQNr2NUlNpIbB3MDxIJCXHtGhVWmJijGwuSyQTQaVSsbZyLfWOet70volJawLk6rbjsXGcRmdR35tMLkMgKbuLdo/sxqAxEMvEGI2OkhNz9IX68Cf9rK9ZX6hp4jQ6GY+N0+RsIpVLkcgk8MV9BbfRtc3XMhAeYO/4XmrsNTiNTjQqDZ3+TlaWreQTaz/BxfUXH/OJPm+diaQjOA3TA/DzzQjz/Ynei3isHjYt2YROo+PZrmfJSblCI8xaey1aQSt3gza5WeRYxPXLrqfStoCKFx0nilBRWDBMrZ1SVyc/oe/fL09271sXYZNjGyFflh3+RYRyJdi1cdK+ILW2UbzlLQiCEY9H/qzBIH8+m5VreAiC7DKaickBkAsZjwc+/GHZffKNb8gZN6GQgJiyYDD6EExBolETYlqNszSKvnYPLuPRTe0niiAUizq3W67v8vLLcgry4KBs9bHZ5PGuXDl3YTE8LG+np0cWqoOD8rVbt04WO/PlsjNoDDQ6Gzmr/Cwi6QiJTAKj1ojH4kGlUhFNR2e1Rs0k1lwu2OH1F4J0ZyJvEahx1DAcGS5UU81bc7xRLyWmEowaI8lcEovaQqOrkaHIEB2+DsZiYxh1RnJijuHIMGq13ECvrbINnVpXlOKbyWXIiJkjJeInNf07NHFI7nWTCqLP6FGr1Ji1ZtRqNePRcYbCQ2wf3M7Fiy7GprehV+sJikEiqQiJbII/9f+JYDJIKpdCr9ZTa6/llpZbeLX/VTp8HQyGBzFoDJxbfS6bl25mZdlKtg9tZyIxQYmxZNZOy5OtM3advUjsTW5G2OhsPLGL/i7BY/Xw4VUfZo1nDW8Ov0lnoBNv2Es0E0Wv09PgaGBl+cp3RcE7RagoLAhmq53idsspyOPjEh27Umw6O4ar0UNbeYLuEYGBCTNhjQZtppMbWg4SrG/lwAGBsTH58+XlcN558gT5yivHDoB8J2QuC4LsGgsE5GMKBKCnR0sg4iSe1iIYIpidAZatH+KitaW0VZ6+H6rKSrmY2xVXyOc0kZBFoNE4d1dNe7t8L3R2yplCo6Oy4HE65XL8GzbIwmc+XHYz9erJM7WmyGSKmu4ZDVS6XNPiNY5lEWh0NrK6fPW0aqrN7mbOqjiLXSO7ivrXXFR3ETa9jYMTBxkKv21xMZeyrmZdoelcvu/NwYmDlJvlBn45MUcym8SoMRJIBqi2VgMwEB4gkAiQFbPYdHK5/IyYQaPSYNPbiKQjjMXH6A/0s6J8BalcCo2goTfUSzqXRqfSUWmtLAisDl8HDoOD/7Pm/xDPxovaEbzQ8wJ/s/Vv6PB3kMqm0Gv0NLuauf2s27m8sThGTaVSsXnp5iLrTD7GZ3IzwvdaIO1MCILAirIVLC9djj/hJ5FJkMgmMGqMGLXGd03BO0WoKCwIZqudotPJLpt4JMvgqJrOTA3NQg6XNYPDHEKjFqktS3D10gncuf1wYy0+3IyMyJ+vqDjy1N/be/QAyObmE4udOBMIwpG+R4EArF0LiYSeVEpHIGKgzJNi45Xl06qjngjHGxsy1dJyPAwPy+6j3btlURKNyq47lUp2/6TT8PzzcP318j5O1mU3U5+YyZaNmQI/vRFvQVxMtibkn1yPxyKgUqlmraYqCAKjsVEO+Q6hElSIoki1tRq7zo5arWZ9zXpWla8qCgIWBIEqaxXPdj3La4OvYdKYGI+P0xvopdxaTrm5nAZXA1kxSygVIpQKoVPrsOgtaAQNeo1sjTFpTSSyCVK5FN6olzpnHRPxCfQafSHIeLFrcWG/k3sQtY+2s2nxkUDb57qe44GXHyCQCFBlq8KisxBNR9k9upsHXpZ7fU0VK62eVu49595Ca4O8dWZyM0KFI7zbC90pQkVhQTBb7RRBkJ+kY0GR4TEt43ELTWKIREqNN6CnuiTJFa0TlNjV0JuCVJKSqqL6cQWOFgDpdM49dmKhMDVOAsBmE2hpMbNmjXleMpiO9LM59enckiS7ew4flkVKLCaL1GxWjsvJ12kZHoa9e+Gii+bHZTdbn5h8TZHJ1ihvxMvTnU8TTAaLRM3ktF2P1XNcFoHZJhmP1UONrYbnu56f0RJxWcNl0z7jjXjZObITh9GBTq0jnApj0VoYj42TDWdpdDQSTATxJ/z44j6QQK/WoxE0hSDdbC5bKGcvSRKxbIwDEwcoM5fR5mkjnApTa68lko6QyWXQqrWFrCWPxVMUaJvL5diyawuBRIDlJcunBRbvn9jPll1buKz+smluoFZPK6vKV51gs0iFdxOKUFFYEBytgK3RKE9YFkMGKZOhd9SEXivSXB1jTUMIjysF0WP7bo4WALnQ66jMxmxxEvMhuKb2sznV6dx+/5Fuy4nEEeuWSiUfT778TiIh7z9vaZkPl91c+sTkG8IFk8EiN9HUjsabLJuO2yJQ5Ep6e9+7R3bzv3v/l2g6Smt5KwaNgWQ2yXhsnP/d+7+UmkqLtjN5fG0VcgHFvJgYCg/xbNez/Lrj16gFNWqVupBync6mC80G9Wo9DoOD8fg4SGDWmqmx1XD1kqu5pP4S7Ho7j+x6hP0T+/HFfWRyGXJSDrvBTpOzSS7sFhvFG/HiMrrY4d1Bh7+DKlvVlDYEEhkxg9vkZt/EPt4cfpNza86ddl1UKtV7MgVZoRhFqCgsCI5VwHYipOOc5WN8au0rZOqaMOhEXNaMPCEfh+/mVE7sZ4qTcbXMxmz9bE5lOncyKVtN0mn5+qvVsjVFrZbfM5nk5ZmM/Dqdlt1e8+WyO5b5PN8QrsJcMSdrwlwtAjO5kqpt1bzU+xK+uI+VZSsRBIFENoFWpcWms9EV6JpW9Cw/Po/FUxBRNr1N7icU7CYtptGpdbSUtWDRWRiNjhJOhgkkA2TEDGXmMrkAXTaOQWPAaXBSZ6/jAys+wM0tN6NSqdg3to9OfyeSJGHVWQmnwviTftpH23mh+wWcRidWvRWz1kxfqI9AMkAqmypKwU5kEgSSAeKZOBkxw0Rsgqe7nqbWUfuOD/pUODUoQkVhQXDsArYCt/+tibK4AQJ7ZcUhnpjv5lRM7O825tLPpq9P4vBAgLSYgqyBCocDt1s4YeFiMMhp6Dqd7GaamJCFSjYrp6rHYrJQMZvlMQwOQnX16XPZJbNJxmJjDEXkNOZ8U79ScymNzkbsevu07r7HsgjM5kp6beA1/tT3J1pKW4hlY4xERgodi9UqNWpBTftIe1HRs2Q2KbtsJnVnliSJLn8XA+EBjFojFp2l0LxQr9YzFBkilJZjVaKpKCadCYfBgU1vo8JSwUX1F3HpoksLvZB6Aj3oNXqiqSgD4QFSuRRalRYBgVg6RjwTZ2nJUkwaEx2+DgLxACpBzp5yGpwkMglGoiNyF2mtnLmk0+gIJoI83fn0vPWkUnh3oQgVhQXDsQvYusH7LvPdLFCO1c8mgZ8/HxjnjbEBYjEBcnrKbHbWtVSyYb37hC6FywWLFsmXNJORM37s9iMp5cGgLFSyWVnEnnWWbIk7XZc9mAwWrAkVlgpyUo5EJkGXv4tgIsjSkqXo1Xr0an1RfZHZMi+O5koqNZYSz8QZjY8yFh8rVB7Nl/cPJUOFOih5oTJT9+FIOsJAeABREjFqjIiSiEalIZKO0BXowqgxssS1hJyUIytliaQihNNhBiOD3NJyCze13FQQDv6En4HwAGdVnMUznc8wFh/DY/YwHBlm3/g+3EY3LoNcOXc0PkpbRRuHxEM4DU4GQ4PYtDYCyQDpXBqLzlJwdy1yLuLiuovpCfXMW08qhXcXilBRWFAcs4Dtu9F3swA5Wj8bf8LPH986wMHDDhrEUmoXpUETZyzUz5OvxRkfU3HLZudxCwhBkANk//d/5eBZjUbefyolu/9cLtkl1dgIf/d30NJy+i77TNaEUFKuoIoEg6FBxuPjbGraxLbBbQVrw9SMoMnM5KrJY9KZsOqs9Ab7sIuLcGsbkLJZsETRqXUYtAZIQl+wj4nYRGFfNfYaDvkOFYRPJpchmU0iSRKpXIoSYwkGtYGuYBfJbJJScymBRIBSk5zmnM6l+fKrXyaSjvCd7d/h+uXXF8aUt9i4DK5CD5/hyDC7x3aTEeUCcg2OBsrMZYzHxolmolTbqllVvoo3Bt+gfbQdBFmIRTNR/HE/Fr2F9zW8D41aM811pqCQRxEqCguOYxawVXw3p5zZ+tlIkkTnRBeH91lxWcwsWT72djyRkfoyA8NGL/v7rezY4eDqq4/fDWQwyAIkk5FTr/NtEbRa2bpTViZbUiorT682zVsTGh1yTZCJxARalZasKDcNjKQjDEWHcBqcNLmbjpoRlGcmV00ej8WDPbuUgzsziNlzSGBHpc1gKh3HXtfNhLoHj9VD+2g74XQYrVqLXq0vWFLyqdYqQYWAIHdpNsiN/ZK5JKFkSM7wEbMAGLQG3CY3Nr2NL17yRR545QG6A91c8pNLeOnWl6ix1xQsNoPhQcaiYyRzSfaM7ykUlDun8hxMWhNGrZHx+DijsVFKjCWUGEu4pP4Snul6ht5gL76YD4PWQJ29jk1LNnFWxVkAGDXGaa4zBQVQhIqCgsIMzNbPZiwYYdduEZ1kpnFFqCjoWUDAZXTitwxyoLOWdX7LcevJZFIWIzfcAAcPylVp84az8nJYtkzO9jndFYST2aTcJycbw6KzEE6FCadkgWDQGLDq5Wqzbw6/ydmVZxcEw0wZQXnryUyumjzBCSOqzk0wcYB4yTAmWxB1zspEfwmDwxnKV09gc+gZjgzTUtpCla2qUPsFoNRUSjAZJJlNYjfY5XRggx0VKoLJIIlsArPWTDAZRCWoqLHVFCrpVtuquWvtXfxk90+KxEqVtQpJknil7xVGYiMc9h8mlUuhU+motdcyHh+nxlZDX7CP8cQ4ArJFZzQ2ytqqtXxi7Sd4tutZMrkMKkFFnaOOOntd4ZgT2cS89qRSePegCBUFBYUZmSmdOyHmsJX7seisuEtT0z6jV+tBEyKWyJ6QmMi7nEwmuPBCWZTkLSpW65GsoNNdQdigMZAVswyFhlAJKmwGGx6rB1ESyYk5EtkEBrWBTC7DvvF9XGS6qKgI20xujdmq4koSdO2zISZgWbMOSdIQSofISWFUbjWO4AocQQfq2r/gsXhwGB2oVWosOguNjkbeGnsLt8HN+xa9D5PWRCgV4pf7fskfe/5IT7AHjUqDL+5jNDqKTW9jZdlKGl2Nhf0nsgkqLBX89ubfsvmXm+kOdHPhlgv5wkVf4C9Df6E/1E9noJOMmMGkMdHsbiaajhZEiU6lo9pWTZWlijeG3yCeiZNIy9VSV5WtYjAySIW5gpHYCF2BrkL13tmqACsoKEJFQUFhVqaGBMVFCfUBLwdfcZNKqTGackXrp3JyBpDZojkhMTHV5WSzHXnvTFYQdhldlJvL+WPsj4XU3JyUI5gMEkvHCKaCpHNp0lKa3lAvZ6XPwqY/MviZ3BqzVcUdm8ixrzNKbbUWi+VcgokAeq2BTDaDTqODlIU9/QNYoxbK3GUFS4g/4acr0MVgaJDdo7sZi4+xvHQ5VdYq7AY7NfYaOXYkHUVCIpFJUG2rZmX5SpwGJ6FkqChgtqWshZdufYkLt1xIX6iP//fc/2NdzToGI4OFUvtukxutWovdYCeUCDEeGy9kQPVH5CqErRWtJLIJuoPdNDgbCCQDjMRGMGqNjEZHGYmOEM1EZ6wCrKAAilBRUFA4BpNDgiTJyfJ4OYecg/jHllBZFz8Sv4KEPxFAFV3CslbzCYmJ2VxOZ7qCsCAItFW28ZuO39Ab7MVtdBNIBkhkEoBcrySpTpLOphkKDzEeGy8SKrO5NWaqipsIu3DplnLeIg9qNewY3kEsE8NpdKJX6xnP+gnE4jSpSgqN+fpD/ez07iSZTVJuLgcBTFoTBycO8mzXsziMDm5afhORdIRgMkgoFaIn0MNYbIyD4wfZP76f/eP7GY+No9PoGAgNkJWybFi0gfsvvp9PPfcpfAkfvz/8ewAcBgebmjYxGB5Eq9aiU+kYiY6QETP4k36koIRL78Khd1BiKiGVSzEeG6fZ3UxbZRvd/m5GYiOMxkbxJXysKl/1rmiep3BqUISKgsI7kKn9d5xOufjZqU6EkifsNRxa+RJvvDxIb3cZZRW5t7N+omRCHs5b7KGtbW6BtKKY7wAtpyI3Ni7cCsLLS5dz2aLL+PGuHzMYHiSVS2HT2bDoLTgMDgbDg2RyGSQkhsJDNDgbEAThqM0NYXpV3HjIyHN9TowIWIzQVtlGl7+L8fg4wWSQeEyFy2JmmWcRAG8Ov8kO7w4m4hNyrZK3Y14cBgeSJPHa4Gvo1DoEQcBusGM32AE5FuWPPX/kme5niGVi5HI59Go9Nmx0THQwFBli7+heXEYX95xzD/e/fH9hzFc2XskixyI8Fg8D4QEyuYwcB6O3s7R0KTqVjkAygDfqxRf34Ta5CYpBMjm5Gq2z0slIdARfwscNy2+gydWkWFIUZkURKgoK7zAm999JJmXBEo3KacQulyxUTlU/HpAn1lvWXUKpaR/b3vTSP2R4u45KLevOr2TD+rmlJre3w9atspsnL7Cam2HzZmhtXXhZ6CPREWw6G3qtnv5wPw6DA51Gh0VnIZlNUmIsIZQOYVQbmUhMEEwG0aq1szY3nMzkqriSFQ7VHXF/uYwunJVOIukI6WyGwR49i1v3EdX8noFhP/6En1QuRYW1AkESGAwPUm4uJ5PLAGDSmAinwkTSkSIrjyRJTMQniGfi6FV6LEYLJq2p8LloKsrLvS9Tbi1n2+C2ovH+puM3bFi0gTp7HcFkEJPGhFlrptRcSrm5HEEQcBgcTMQn6A50Y9Ka0Kq0aNXawjaimSirylcpIkXhmChCRUHhTDCTKWEOzdYm998xGOSO0Dt3ytYUh+NIK4JT1Y8nj8fq4cPrK7jqLD8j4+njrkzb3g7f/jb4fFBTIwfKRiLy8oEBuPdeWawslCz0yRVkL6i5AH/cTzqXZiI+QSwdo9ZRi11vp85Rh1lvZig8RHewmzJzGR6Lh2Z3Mzq1rtBf52jM7P4SUGVsBLxQXQGt6+v4SVeoUNJ/VBpFkARimRjl5nIsOgvdwW6WuJZg0prkcvVvCxCQRcresb30h+Q4EoPWgMsgF6YzqA1EM1GMGiPhVJj2rnbSuTRWnZXL6i/juZ7niGfiPNfzHKvLVpMRMzQ4Gii1lKLX6Av7UKlUNLgaODh+kAMTB2gpa8GkMRFNR+ck3hQU8ihCRUFhBk5QR8yNY5kSZmFy/x2nE157Td5ELid/3OeT2w+IoixY/P7578czGUEQKDG7KTEf3+dEUT58n0+umZI/r06nfK737pXfX7VqHs/5STC1gmy5uZzh6DD+hJ9oKko4HQYJFjsX0+huRKvSMmQdos3TxmhslEAiwCv9r6Afmr3421SO5f7S2bVUjFagU+sYj48Tz8YBKDGVUGGtQKPSMB4bZ4lrCXa9nYn4BBrVkZ/7gfAAO707GY+Pk0jLGUv+pB+LzlKIpYmk5Oq16Vwag8bAratuxWF04Da5+cW+XxDLxNg5spM6Wx3NJc2UmkvpCnTJIuTteBqT1oRBY6DKWoXL5KIv3DdrZ2oFhdlQhIqCwtvk4z527IDnnpMniFRqzjpibszVlDAD+f47er08vsOH5TLzBoNcHM1iOXIMPT3ymPv75dcLxTIBsgDs6JAPf6oQUank5R0d8nqLF0Dj3KkVZK06K/WOejQqDUtcS4hn4qRyKZaULMGmt9EZ6KTCXMGesT34E36qrFV4LB6SueSsxd9m4mhFmIfCSQxaA+vc64hlYjj0DsbiY9Tb61GpVIiSWIgJMelM1NhqGI2NolapSWQSvD7wOsORYUxqE6JWRK1Wk8gmyOayOIwOJFHikP9QoZ/RpXWXEs/G0Wf1VFgq+GDLB+XOzpkog9FBBEFgkWMRDoODrkAX47FxgmIQURRpcDXwiTWfIJlLMpGYoMRYQpunDXWh3LSCwtFRhIqCAkfiPv78Z3j+eXliqK2Ve89I0px0xLE5SVNCMikLkoEB2eVjs8k1RvT6I0XQTCZZ+4yNyVagVOr0F0c7FqGQPCardeb3rVa54WAoNL/7nRqAfLSYl3wfmmQ2SSARIJlNFirICoJAo7OxkD1jN9hJJ9OEUiHG4mMgwa6RXfSF+3DqnYzFxigzldHgapi1+NtszFaEOV8sLpmTC7q1elrZMbyDkdgIToMTERFRFBmMDFJnr+Pa5msZigzRF+yjfbSdYCpIvaOebC7LQd9BMtkMZq2ZpCgf70B4oFBxdkXJCjY2bsSX9BUESDqX5tJFl/Jiz4tEM1H+4/X/4I41d7DGs4a1nrVvx9OkGYwMYjfY+dXBX9Hh6yj0P2p2N7N56WZaPa0neVUV3gsoQkXhPU8+7sPvl6uhAjQ0yMXFenvlCb+lZR5cEsdhSpCaFh+ZVPUSLvzo/WnG+hz4AwbMZgGjUXYDCYJsTQkG5cnYaJSFSyQii5j5LI52PJP9bNjt8mcjEVmjTSUSkd+32+dnzFAcgJxKyR2anU7Z6lRXV5w1FcyM0JPawUC4n1QuRSaXoSfYU+ilA3KAa5unrVC3JJwOE0vHsOgt9AR6OOQ/RJ29DofBQSqbYjAySCAZoK2ybV562kwtFucyugppv2OxMYZjw1RZqzjLcxZtnjY8Vg+rK1bT6e8klArRVtHGUGSIQ/5DlCRK8Ma8kAW1oKY33EtWzKJVaTm3+lwW2RdRai5lkXMRkXSE8dg4+8f3U2Iq4bpl1/HEwSeIpqM8susRouko62vWY9QaCaQCiJLInwf+TDKTpMYuV7+NpCO0j7QzEB7g3nPuVcSKwjFRhIrCe5rJcR8WC4yPQ2mpPMHrdPLkNTIiZ1+ctEtijqYEb1ecnYfenlTHQuhH+6kV+qkzTyB1rUGVdSGq3KRUBrTa4saBkiRXbtVqZUGxZs38FUebOtnr9SeWXdTYKAuE9nZZjEzWbKIoW4xaW+X1pnIiQmlyALLHI5+vgwfhhRfk89TQcKSXUIoQnaFu9CUp1pxVQb1HIJ6J0+Hr4OW+l7mq6aqiyrIOvQOtSotdb6fEVMKf+v9Ed6CbSCqCWWtGq9Zi1VkxaAx4o166/d20VrSSyqVOqqfNTMXi7Ho7zSXNaNQaFrsXs7FpI8tLlxdVyM334im3lGPQGuQy+44kOTGHP+knKabQJMoho2H9orVcs+R8ysyljMRGaNI1YdVZOTRxiJyUw2P2MBIb4aOtH+Xn+37OWs9agskg24a20VreymLnYl7qe4lkJklLaQuqty+00+DErrOzd3wvWw9uZVX5qsJ7CgozoQgVhfc0+bgPj0ee0DIZecKCI5aKUEie3E7aJTEHU4JXquDpXeUE9eAxBDCO7yARTtGBh4PxWiStnsRogqFgnIxBjdGiJZGQN2m3y2P3euUJvKpq/oqjTZ3s80XYTiS7SKWS430GBmQr1eRQnYEB2dWxefN0o9OJCKXJQrSpSRae7e2ytay+Xt7fjh3ytioqJIz1PUiGAOLYEg5uy2C+cBxXmZoLai7g6a6nebX/VS5bdBkmranQW8eis5CVsnQFukhlUzQ4GzjsO8xobJR4Jk6jqxGrzorT4GQsPsZ4fLwQsCpJEr64j5HoCAAVlgrcJneh/oo/4SeRSZDIyiXojVojLqOcnTNTsTi9Ws8az5pCoGp++3mXi16tL/QXylthnAYnVr2Vw31RRroq0QUqWWRdytKxxZQNV7FydZad4lN0BjqxaC2FqrIjsREsOgtrPGu4sPZCdGpdoTbK5Y2XI0kS/7P3f6ix10wTIiqVihp7DR2+DroCXSx2L4BgJIUFiyJUFN4zzPQ0nkzKk57RCGYz0ywUGo2cVZPNHgmsPWGXxDFMCVL/ADstHyCoLaOpUULY0QmJKJZ6D01k+dN+CwdHHTidGRoI0J9Qk0jYEEUBjUbeXDgsdxa++GLYsGF+UpOnTvZ54WOxyK87O48/u6i1VY73ySc/DQ7K57a1deag5RMVSpOFKEB3tyxS8q+zWVkgLV8OY/4Ug91plq2yYCyN4+030b3fjrN0DLfJzcW1F7NvfB9DkaFCt+IlriUEkgHG4+NUW6vpC/XhNDgpMZcwEZsgkUnQG+il1FwKQDwdZzA8yLnV55LKpvjZWz9j2+A2RmOjAJSZy1hXvY6VZSsZigyxZ3QP3cFuwqkwVp2VBlcDq8qOVHGdWizOoDEUhIw34i2ImFQuJbuubDVYdBa8UW/BZeSsdFIqrUIbKMMshlm80sL5DWehEa2M9AvsDMOaC69myPwmb42+xWhslHJzOVW2KhqdjUVF7MrMZcSzcUxaE96ol2Q2WSjxPxWrTm7kGErNczCSwrsORagovCeY7Wm8vl7+/0QCKipkK0RPjyxaBEGeyNRqWQT09s7ukpgTxzAl+C219NdfjKdKhRANy34op1MeiASSJJDKqDDoRJY1J6j29dOvX0I0pScWkzf/vvfBxz4GK1bMX0ry5Ml+6jYFQV5+ItlFra1yvM+x0sBPRihNFqLh8JGsqYRc+Z54XH4tSWC1p+kZ1CMmVQhWEWdpijGvkUhQi82ZodJaSSqX4vKGy3EanQWLyGP7H8NjkRsUalVa0mKaCksFvriPgdAA0bRck0REREJCJai4sO5Cfr7v57wx9AZaQUutvRaAsegYj+9/nCcPP0m1tbrQ7K/EVEIsHaMn0EMymyzKHJpcLC7P5Lov+R5CiWyCQ/5DhXXyLiOD2kj/QTe+YI4VzXraqlbiNNoK57izE4YOlXPVVZtY4l4CgNvopsJSMS0YeHKrALveLqc5pyOFxoOTiaQjhfUUFI7GKXUMPvjgg5x99tlYrVbKysq49tpr6ejoKFonmUxy991343a7sVgsXH/99YyOjp7KYSm8x8g/jR88KIsOq1X+e/AgbNsm/xh7vfIkt26d/H5fn6wfwmF53a6u2V0Sx0XelNDaChMTcOCA/Le1leRtnyBVViO7njKZIyk9QCShJhLX4HElMWhFuv12JkJ6UkmRZFKOS9Hr4f3vlwN/57NuyuTJfiaMxhPPLlKp5HiftWvlvzOd26lCSRRhaEieQIeHobz8iFCaSr4b8/AwvPmmbIHp7JTrzXR2ytdXr5evsdGggZyWeCqDBGTTMDpooPuAlZBfSzyTwKAx4LF6qLJV4Ta5SeVSpHIpjBojVp2VUnMpgUQAJLlBYywdI5lNIrz9n1lrJpgK8os9v+DN4Tcxa83UO+oxa82YtWbqHHXE03F6Aj0MhYfI5DJUWatwGpxUWavIiTlEUSSQCLDTuxNJkqYdsyRJ7BjeydBoEme6BTHmRCXI3ZWbnE0AlJpKWeJeQjAZZP/ACP39AkvqbLRVrSmykEwWooGAQJOriVXlq4hmojPu1xv1UmuvxWV00ehspNndzEBoAFEUi9YVRZGB0ADN7uZCvyIFhdk4pRaVl19+mbvvvpuzzz6bbDbLP/7jP3LFFVewf/9+zGa5StTf/d3f8dRTT/HYY49ht9v55Cc/yXXXXcef//znUzk0heNgPjI9zhT5p/H+ftmFs3fvkeOorpbFSGOjXNU1XwV00yZ49VXZsgKy5WU2l8QJMYspwRBQoe962/Wk1cp+qLcVQianIp7WUGLLUFea4KV2OwNjbnJxDSqtPNnGYvDyy7J3Sa+fv+uVn+wnu8Qmk0jMf3bRZCYLpe5ueOMN2SiVycinqKpKvpYzCSWXSx7zk0/KYsRkkl8LgnxPj47K1152JRlxmEyMB72MdNbSd9hGOKhjsNtKSXkCx5KDXHV5adFEno/7yPfXaXQ2EkgE2De+D3/Cj01vw2awYdVZsRvsLHUvZTwxzu6x3dj1dlZXrC6ySiSzSSQkNCoNvaFe2iraioJhnUYnE/EJamw1s2YO7e8O8PTTkJhYS1/OhFYvUuZJ0LA8hKsshcfiIZgMclXTVayrXkdPfxrJZWVFgxmNZvqNYjTK5ymZnDmIV6/S0xvqZSA8QLm5nNbyVgRBQBAENi/dzEB4gL3je4uyfgZCA7hNbjYv3awE0iock1MqVP7whz8Uvf7xj39MWVkZO3bs4KKLLiIUCvHII4/w6KOPctlllwGwZcsWli1bxrZt2zjvvPNO5fAU5sB8ZXqcKfx+2LNH1gSjo/LTuCDIAmZoSH4aNxjgr/5Kdu309cnugLY2uPBCWLpUdi+caGXaWUVe3pQwCZdLPrcdHdDUaEUoLZUHaTCgUYnEUyoqHFnGQ1riEYmyUhFjlQadXnZRBQLyJJ4XX3kry8ler6JxNRWLHkmS75Hm5vnLLppKXigdOCBn6oTDcmZWPk7l0CH5ul1zjSxaZkOvl2vPhMOyWNFq5W3HYvJ9EQwKVLvd7O9MMdRrhLSGsso4rsoQo2MSE9uW0mVwM9IoFM7lTGnCS0uWcmDiAJlchqyYxWFwUGevw2PzYNVZCynPoVQIUSq2NOTEHAigQkUim0CtKi6KplfrCYpB1IKaeDY+LXPI64Vn/iAw2G2hsVbAaIiTSqkZ7DET8Olou3Ace0mO0dwoqVyKKlsVlILbJt+jcxGik4N4/9z/Z3aOyBVutSot5ZZyEtlEoUZKq6eVe8+5l60Ht9Lh62AwPIhBY6C1olWpo6IwZ05rjEro7XQJ19u/aDt27CCTybBhw4bCOkuXLqW2tpbXX399RqGSSqVIpVKF1+Fw+BSP+r3LfGZ6nCkScYm925P09gsYTAJWpw6NVigEUfb0yJPthz8MZ50lT2KhkDxx6fXyX4vlxETK8Yq8oh4vXQKeiiaM/hCJ3glGJQ817gSk03R0GdDoVZQtMiOYBCRJFimlpXKht23bZOFQWTk/12vm3jPytr1eOYxmvrKLZsLlki0mv/61fH3q6o5cD7NZ3n80Ci++CBddVHyt8g0bL75YHn9Pjxz6E4/LMUkVFUf6JdXWglFtJeerRSsm0LlDGEr8oJNoarBBpJzBLjM7dsDVV8vHO5OFwaCW4y78Wr/sAnE1UmoqLVhGjFojWpWWrJglkZEtMXnUKjVIICKi1+hl4TKJVC6FVqUlJ+UKsSB58tbDWESLpy6GSgcqtRGjKYeh9khwcPM6X9FnT0SIeqweKiOV9AZ7EUWR1vJWSk2lRDPRaTVSWj2trCpfRVegSy6Qp7fT6GxULCkKc+a0CRVRFLnvvvtYv349LS0tAIyMjKDT6XA4HEXrlpeXMzIyMuN2HnzwQR544IFTPdz3PKci0+O04/US//1B+ncvhhy4nAkE0QROJzqjCZdLjl3o75cnq0OH5OOtr59BlF0p4dEfxf81xXTiTbl4+g/CcYu84h4vTkZLz0Yv9rNU6Od9nn389uBiBlPVVDXowGgknZYnYr1eHo5eL1tS0mnZ1TFf1+tYvWdOpWAVBPl0BwLy/+cL2QmCbA0xmWTxMlONm7zbqL5eFjtLlshCZXBQ/mwqJXveliyRz1V7O5Az0rLYQGmlAaPJjVqlwagxkjQL+P2yZWfduiOBw3kLw47hnRzoH2U8HCUZNuMyumlyyyJlMipBhc1gI5KKEE6HKTGVFESMQWNAQCArZmlwNJDIJgqNDCVJIpAIUGmtJJKOsLRkaZEbKh/L01hrJhMuZSgyhMEib08QkIODhw1ohgOsaagrfPZEhKgoivy649dE01FWlK5AQiIjZnDoHdhLp9dIUalUZzQFeXKl4cmZUQrvDE6bULn77rvZu3cvr7766klt57Of/Sx///d/X3gdDoepqak52eEpTMHvk+jfH8MjBRD6RfnXymoFQTipTI/TxtvmoNRhNTnVcjR6AXQ5eZZLJaHCAwYTarUc67B7tzxpzSjKdoTY+f0ONpXvQEjPYBoZHpaDQ3p7IZdDcrrYObaWIM00tdmPW+QV93ixY9C34KISIZXEv93MM1+3kZIEckFZjLjd8mTb3y9P2plM8fbm63odrffMqSYSkd1bkiSfZpCtKdXVcpsDo1EWEMGg3KEgPz69vji+xmaT/zU0yNsMBmXrym23yRN1LCa/X1cnoFabisbwdlwzsdgM8TBRDxzeBJ0xTIkM5bF1DPIawVwfJXVHOiZLkkQgGaDcUk69vZ5oJkpvsJcySxkgZ/2YdCbcZjdV1iqi6ShDkSHMOjOxdAydWodKpcJldE3rPJwXZSaTQKNGLvGf71KsV+sR1QmGQyKLBfe0zx6vEO0KdNE+2o4oiRz0HSQn5VALauwGOxWWigVVI2WmNO1aey1nVZyFXqNXxMs7gNMiVD75yU/y5JNP8sorr1BdXV1YXlFRQTqdJhgMFllVRkdHqaiomHFber0eff4XQ+HU4PWS/OWfSf1awih2gSCB0wHNS2H1anC5igLsFhyTzEFCbSsOm0Q6KxFIGrEYtGgTYTLjIaJmI3q9gF4v65qZUnqFgB+Pdzf9vhz+qjLclepi00hNDTz1lBzdaTKByYR/JEN/zyieqhhCYHWRzXyuoqG4x4sAyC9W6WHVM3KiUGWlXOclXzI/m5UtKQ7H9Hpy83W9Zus9cyrxemHXLvmy5mNTUin5MuTe9oxEIvL7u3bJ2T15V1tNzZGsrskiVBBk3T06CsuWHVlus8niJZ2enuWU9zibzcWBw0dcpALVHgtGI5T5F+Nrj9O9XU9G3EddjQ6QhUhWynJu1blcWn8pe8b2sG1wG/2hfkCuQ7KxaeO0OioT8Qm5GaKzvqiOymQmBz27LHIxty5/F+PxcYLJIGLKSJXDw8bmZXis039fj0eIdvm76A/2y1VmDXa0Ki0ZMYMv7iOWjlFnryOZTR5XjZT5snpM3k4wGWTb4DZCqVBRmvb24e082/UsFdYKjBpjQbwoHZ0XJqdUqEiSxD333MPWrVt56aWXWLRoUdH7bW1taLVaXnjhBa6//noAOjo66O/vZ926dadyaAqz4fXC//4vhlf2oc+sJ+GuxKJLy4Eb2/8i/73oIhI61ynN9DgpJuWzVuTS1JUnGPHr0GqyhOMaYqINdSiNqzxFRmXAapWPY1r6rSRBVxfGTJhRZyNJnQTq5BHTyI4dcuAEyP4GgwFSKZKDUVLhFEZzBLosR2qhvM3JiAa3G84/X85iiUTkiUSSZJESfTtjtK1tepX+U52Zc6rIa06tVn667+4+UuDXZpPdQV6vfMnztVKqqooDbfPM5NYQBHkbjz0mX4/RUTl+OR4vFjZ5z55KJQubvPaczUVaU+pk8/pVPLvdTHBApM/6IoIA5eZyzqs+jw0NGwr9d65qumrGyrSrK1ZzXvV5s1amncrUWJN8MTe5QWCGwV49Z7WaWV43++Q/FyEqSVJBWBm0BnRqWYTp1DqcBieBZIDeYC8WvWXONVJmt3qsQZ/xzNmCNxwe5uW+l+kN9pLNZekOdpPKpji/5nzMWjOCIJDOpfHFffSH+tGpdZxfff5xd7ZWOL2cUqFy99138+ijj/Kb3/wGq9VaiDux2+0YjUbsdjsf+9jH+Pu//3tcLhc2m4177rmHdevWKRk/ZwJJkiff/ftxOSVqDRo6fCU0Wf0IZXr5l3pgAKmzE6/jbJqXCqcs0+OkmJTP6lZlWLfEz5PbyzHpcpTY0qgQEUMR4voS4sC558ofm5Z+G4nA+DgJcwn6nIhBWxzYiM8nW1LWrZOtKQBGI4ZKA/r+BIm4gGV8TN6OzVb42MmIBkGQK86Oj8u1QPK1QyRJ3oXBIGc+n+7MnFNFXnNWVcliZWJCzvDJW1YEQT4PLpd83EuWzBxPVVoq68WBgSNujdJSGB+XGO+N4XGlMbo16FusDA0JdHfLVpX6enlbY2OyS+2882QhmN/H0YrhuU0urlnjZGhsGetWXYbDlSsSIiAH45aYSygxl0w79pkKuR2NmWNNBFQZGwEvVJcXj/1E8Sf8ZHIZGhwNDEQGMGvMhcDYfD+h7mA3VzVeNacaKbMVp9veMcizf9BQkTNiFBzHDEZv97azpX0Lg5FBBEkgkAwwGB6UGy0Ge1ldvppzqs6hN9hLPBOnydVENB0lno1j09uOu7O1wunjlAqV733vewBccsklRcu3bNnCbbfdBsA3vvENVCoV119/PalUio0bN/Lwww+fymEpTKIoBjQewLX/AIIoIrhdrMl6GY1Z6Ay48FiiGM02EsEU3l1RnBtjrFljWZiBtJNs4ILFwoZWH+NhPfsHrCRSasiIkNOj1qo4rw2uvVZ2GUzLeshkkNIZvKKN5to4Luuk4I98gINKJftfJuEyJamtSNExbKPJHkWYFDQyH6LB44FbbpE15YEDcsyE2QyXXipP5H6/fPinMzPnVDG5hkpDg5xGvm2bHAzr88nipaRELnK3du3slXODQTkGY906eZt6PWz7vY/x/aM0aXoR+uSiLDWlpVx3WRPP/sVJKCSLEICyMvmzU9sSHKsYnskkoMXCItsyqspPySkq4nQEPSezSTJShvW16/n94d/TF+6j1FRaEBhj8TFMGhPva3jfMTN7JElip3cnwWSQJmdTQRykg258by2lfzSErq6b8xvOIpkUZg1GHw4P8+P2H9Mb7KXCXEF3UO4i7Uv40Kl0RNIR/Ak/XYEu7AY7dfY69Bo9oVSITE7+fgqCMC+drRXmn1Pu+jkWBoOBhx56iIceeuhUDuW9w3FUZ5uWPpsQqN1TyRpxGI9Hj8cY5arGw+wcqaQvaKcr4UAdDVNf4uPi8yN4PDMUXTi1Q54bU2zgHleKWy4aZkeXnQP9ZmLeMOZGB8uuM9DWduRpeFrWQ1qLN1iCsyTGmoZw8ZgyGfmR22Q6EijxNoIAa2omGPWKdAYb8KS1GHPzKxo8HjlFNj/x5s/byMiZycw5VUwtNtfQIFs5vF55mSQdKYd/tMq5o6PyPZ6vs+LbN8LAc91ysHiFRd5JKgVDQ7iDQa5Zv5bBmJPzz5djfioqZJfI1Gt2povhzcSpDnrOF7lzmB38VfNf8cbAGwxEB/DFfWg1WmqttTSXNLO2cu0xt+VP+OkP9eOxeCYFHEP3fjvxiJamJoFodoR4LoLNYpsxGF2SJF7ue5mB8AAV5gr2+/YzEBogkowQy8ZQo8agNaAW1PSH+lFH/n/2/jw6rvS6DsX3rfHWPGGowjyR4NQcAPYsNVtyt7rJtmIpkiwp8SBFsmMneo6jPFv28lrO03ovz8+W4ziy8yz7JZKTlfws2bJlWbJa6kHdLXWL7IHg0GwSIAEScw1AzfN4f39sfriFQgEogODYddbCAlB1697vfvfWPfs7Z599tPBZfYAE6DV66LX6lfGYdCYEy8Eb6mzdtJ23Zq+fe8m2INwhCIDRKPkMNhtQrugwHvchGD+A4855+FpL8NlSOKIsIpE3IJ7SoFwB5nIteP6UBUdlNnO7kQfgTRGUqxMD9znKeGZPGA/ro8gd9EB+agDufdLK2OuuRA02DB/QY0Q6A5/LB5Jar5tOR2JIW5vqMaurKHRLOO66grH9uzFbsiE4vfOgoR6f4HZW5twMq6fxodEQcCgKL+/AAO/jhsGCoiD31gXkE1qY9rcA2uuTYzJxI78fZv8kDJ6j6O+XNhSRu91ieOvZzSQ914rc9Tn64E/5kS1mIetlpAtp7G3du6p0ej3LlXIrLQiEJWN6hPwmuFrz16Mesaqox1oyeiQbwXRsGhIkXItfw2JiEdlCFgoUmLQmFCoFFMoFZIoZGLVGpAopTEWn0G5tR5e9a1XTxOpeRU27c6wJVO4Vq6fOlkoBzz/Pnw98AHjqKUCrXSUrX6nwYU85citabZ1ILiYxNpXACU8YgbQN37+6C7GEFo7sIhaLLbiaH8Brz9nwwinutpEuvYrCUL2Qx/F6GZD4/vdvkqBcHeQhGY3wjPReRwqNVD1IcOe7IX3/wlomZjBID6XV8kREqERo109Owre7Hyf+zW5EZOmWgobbUZlzs6wRjY9jx9ZJ3WEdsBCJQA7Nwug5gGxBC6upvPqALheyi1EYHWnI8sZRw9shhqcoCsKZcF0C7q2weiJ3XqsX2VIW/pQfHvPa8uf1rLYFAQAUC1oU8xoYW8oUuNPWRD1qyOi5Ug7lShmpYgrJfBKlSgklpQST3gQFClAAcuUcKkoFGkkDRVFwNXIVHbYODLoGV5WO+1N+DHuGGwJZTbt11gQq94LVKz04c4Z640LZ6rvfBR54APj0pxEZeRJvv80Haamk+td8XsJCrAs6Yw5vB1N4cGICY+k2xOZicKdnMJbajbTFDrc+BW9vCrMRG155hSBnI1Dh9wMvvACcPElSIsBAhKjcqH6Q76ig3DbCC2ud/DpJ/z172KpYvG4ysSIqGGTJSH8/8KlPQerswD2CGeqbyNtls/yRZc61ycSfHUBmjfAu6qbu1gMLuRzcugR6OsqY8JsxJGdWgxuDEf4wMNyeg9u9eXrzVorhLSYW8fcTf4+TcycRSoeglbTw2Xw41nsMTw4+ecuqVapl9GfjswiWgzBqjRj2DG+pxLc2OiNJEvSGMvTGCnJ5DWKVKDptnaujHjURMgF2KpUKKpUKCuUCew1BgkbSwKgzolgpooIKymCLAqvRCqvBCoPWgHKlvAKyXLKrYZDVtFtnTaByL1ht6cGZM8DXv86IitvNn1SK7MvZWWT/lRFXrz6GYpEhdPGdNJkAedCChcoQrgZN8Offwew7aXgr85gw3Id06wB8PTpIpSRwbRLerl1IKVYsLKwPKq5XO+P110l87GE3e8zNsdR03z769OrQ+I4Kyu1EeGEjwNPezpOfmWH+QaMhieLYMQqd3Msm8nZvv82LKZa5ssx5GRgA7rtvR7z1ZphzS2BBliHJRox0BBBMyJj0m+Fz5WEylpHNa+EP6OCyZzAyqmkYY92KlNtZ/1n86Zt/ijfm30CmmIFWo4Veq4c/6cflyGVcjV3Fvxz9l7cUrJywnqirfVKpVBqSzK8XnTHbTbC1RjAxAfT2WzHoro56rI2QuU1utFvbIUkSLAY2uy1XyqhoKpAUCcVyEXajfaVcus3chvd0vweHfIcQy8W2DbKaduusCVTuBasuPSiXGUlJpSjbqdWqQhudncC1a8j+/76FhOVRtLRq61ZJWFotWMYQ4ruPIZ/KodQpI+Tvg8umgWRUIJrLGMOLiNl3we2W6oKKqmpnWCz02+J4HR307X4/Zc9rpEbuPEG59QDPvUYKadREqnFmhlKx0SjnIJ9fUTBGJsPXAgHO0Q2ClQ0xp6LAZ4jgxKEcIrtNyJlckE1S/UtxnVjim5jA8REzxq45MRsyIRgzwqgvY1iewsgxO3z7XHUPta3x3aAtJhbxtbNfw+nF08iVcjAbzDBoDSiWi5AkCal8Ci9eexEDzgH8/KGfv6VpoNrqmLP+sytNCAWAGfYMr9uEsDY6ky8H4R5woT9xGI5sHwxlB8obkNElScJoxyiev/o8orkoXLILwXQQyUISOkkHk94Ep+xERanAarDCrDfjkO8QPr7/44jmok1l2rvAmkDlXrDq0oOFBaZ73G6CFIAgRZTRdnbCNH0JtqFlpNPtcDoUSLksUC4BWh0U2YR0WoLNkIOjEoWxfwBJvYyiVoZRn+f+JAmwWpGPpKG35GCzmVb8dLWJviiVylrfrdMx7VMsMroyPLxKauTuEii7i0ghlQqBYTxO4bRtdYUWqcaZGbV1cTpNYGKx8IIajYDBQGJSOMy/f+7nbg6Aq2JkS/k8PNWMbKkOOKoilvgi7+DEsA+RQTtyySLkyCLcnSZITzx808Fmo1wTUdVyJTyJQsIGTckNk8UIvTUJWSsjVUxB1srIlXJ4efplnNh1oq4uy62ws/6z+PIbX0Y4E0a3oxs2gw3JQnJNo8JaqxedyR9y48wZqaF02r7WffjA4Afw8vTLKJfLUBQFiUICiqLAZrChXCnDbXZDr9Fjl2cXjvUeg0ajaZYg3yXWBCr3glWXHggtdVGrqShEEDYbnYVGA1MpiAFnFNeKFvjfjMBVCcOIAvIwIKrxwNDuRl9XCT5TDD0dZYxd00OvqSBf0sBkYFt6RadDNAl0OovQ6Ux1QUUuR/8FqH1ShAn6wvQ0t6vuT3M3C5Rt1Xa8NHsDO3sW+Na3eJuI4w0PAx/+MHD48BZ2FIkw3TM9TZCi1/O+y2RU4pPJRIGTSoVI6Lnn6GH271f3U49hLQBfo5Oy3RbfVbkiaXYWnvx1T7hCtr654X9/0o/nrz6Pl6+9jGA6iHKljDZLGx7qeggf2vMhdNjVtGEkG8H5ySUsn7sfyzOADAeKxjJkdxDW3iuQ7SUUSgXIehnBTBCBVOC2AJVKpYJvjX8L4UwYB1oPQKMhcdWoNaLX3osr0Sv4u0t/t9KosNbWRGfMvAyN3AqSJOGJgSdQKBcwEZ6Ax+xBMp9EtpTFcnYZWkkLl8mF3e7d+NShT62a36bd+dYEKveCVZcezM7SMWQyfGjncgQoIreSSsFtzuFgXwK5M5dRUXJYRgticEKPIjqUeWgSyzjY7YEHCkYQQCAuY2bJhEDUiJ7WLAolDaJRLazmPAYGJQQC9UGFLHOBDawVxZIkrHQvTiZZOLNRePeesaqQhj/vxli0D7Nzmp0rzV7Hzp4Fvvxl4oLubuLWZJKvz80Bv/ZrWwAr2Sw5KdksQ2OxmNqKWFEIXEol3nvlMsFHKMQ8oKhnr8ewbm8nSdnpZOpys0m50Rbftylt50/68een/xwvXn0RqXwKRaWIYrmIycgkzgTPYMw/hs898LmVyMPMfAETr/cjF7RDMp2DwZKGpmRBNtCDYtINx/6TKJquwQwzNGg8PLbTHYWnolOYCE+g29ENjUaDZCGJQDKAeD6OslJGvpTHyzMv4+T8STza82hD+9xKsNJn8+HErhPwWr0rPZLiuTjare3otHfiUPshHOs91gQpd6E1gcq9YmKF2NICvPaaSq612ej1TSY6yYUFSAcPYqQ/huClCqLuLnSbM9BqFZTLEpIZO9zZeYxYw5Dc3fBdvowTo2YY9AqeO9OKd2Zt8NgK6NAtoGO3DZG8FS53fVDhdrMvysQEfUE1R0VRCE56euhTSiUu0O92gbINrSqk4Y+Z8GzkAcSc/fC9bw9Me/t2rjS7xioVHjYcpoKrWMy6XEz/XLjA9w8ebDANlM2yqY7NRtBVKKg8KFnm38UiQYrBoAqcBIO8EQqF+gzr6WngzTcZWXn6aZKSN5qUjfTrG2Vk3+K0naIoeH7q+RWQAgBaSQvZKKNYKiJbzOK0/zS+euar+C3Lb8Fn68DEBTOQc6GrdwGRYA75igZWowaatnnkQ11ITA8Cuy5DMSrosnfBa63f0LXa1uutcyNk0ng+jlwpt5LumYpMIVfKwWqwQqfRIa/L42r0Kn4w9QMMuAZuCmlVpJC20iOpaXe+NYHKvWQ+HzXGi0Xg93+fRIS2Nq56o1HyV9xu4KMfhS80hePHvBgLpjEbMiGT18Cor2BPTxoj7Vn40gFg9DEgFIIv8g5+7qgPI30RnL5kQXC+AJ1FhtTdjeE90rqgQoKCkb4ozri1eOu8EcmkEd3dfFCEQvRrDz4IfPzjqvzIHc1FvZE8TVVIQ+nqxlj5KGIpO4Zib0F6cQIwfxDWgYGdK82usqkp+vru7rVARKPh6xMT3G7XrgZ2aDKpIRlh1SrU5TL5UdWD12jUlsdnz65lWItIDKCG1bq6No6ObKZff8cxsoFwJoyXZ15mFEMvI1vKwqa3QZIkyFoZZaWMilLB1dhVvDLzCp70fQLRgB2D3WbM5WxosbQgkPQjpQCyQYZkCyAcsMLd5UJLSwse6X5kU97Fer11xpfHMRWdwnu634NeZ++WHbvD6ICsk5HIJxDOhJEr5eCSSUgulAtIF9Ow6C0olAo3tZ/OVnskNe3OtyZQuddMkoCPfITM1K99jR5ocZFI4NAh4NOfZvj9b/4Gvj4JJ7pCiCT1yBW1kPVluG1FSBUJmM4zBF+Vx99fCWLffUZEHhtEbngP5F7n+r7a74f/hXdw5lQe+mk7LOFWLMy1YHHaBmebEX19bPDWiFjcHWE3IqFbE9KI5CyYTbnha81B0veS53HyJNDXB0mjabg0u1HcFI+rNKV6ZrORfx2PNzgXovHOhQsqB0VYLkeQUt0DyWwm4NBqCULqMaxFlKa1lfM7P880kN2+fnTkTtSv38QCqQCCqSD0Wj1yRaZcqhsUWgwWxHIxSJAwHZtGwBRDoeDC3o4+5INhZEtZlJUyIpkIErkESpU4dMogBmz78Hj/ATwx8MSGzn/d3jrlAuK5ON5ZfgdvB9/GEd8R9Dp6txRhGXQNYtgzjDcW3oCiKLAarMiVcojmokgX0ghnwmixtqBUKeHt4Nt4qOuhJqC4A61WGmkHJZG2bU2gcq/ak08C738/eQHLy0wJjY7SWYTDq5r2eexFAFVs1uoHvMezKo8vyTI8m92xfj/8f/Uynn3dhZjeh97hMoZ3BxGam8Vk0gvbvl780190YP/+OzRyUmvbJWwKqwlp5Eo65MtamHRFTkBLC6NdgQDQ0dFQIGAruMnh4KVMJpnuqbVkku87HA3Oh2hVHInwJxYjyimVVFa00ciIicnEyEgyyVSOyVSfYV0u88diYWqolmFdb1LuVP36TUwjaSBBQrFShFkyr3pPgoSKUoGsk1FRKoAuxwaTcGO0YxRO2QmH0YG5+Bzi+Th0JSfctgH8wugI3rfv4Kagol5vnUg2gtOLp5EupuGz+lAsF6GTdJgITyCYDuL40PGGwIpGo8GH93wY48vjeCf0DlqtrUjkE8gUMiiUC3CYHNjfsh/hbBjzyXnMxGaaQOUOMkVhoPOttxjA9PtJFbPbd1QSaVvWBCr3smm1VKOtta0+4LeSx1cUKKfHMHbRiJilC0MdGUhQgKyCjk4NfEsXMRnRYmbajv377wKUcqOETWBNSEPWlWDUlpEt6WE1FOiEw+EVB75ZIGCruGlwkJfz7FmCkeoASKVCMu3hw9yuIRPk7UCAQMVqVZnRqRR32tXFuXO7uc3AAEXwBIABVqdttFo14qIoPHm9Kpted1Jugn79za7C8lq96LZ3I5qNolAuoFgpwqA1XD+2Qu0PjQ7tlna4ZBe8rYaqr6obRztcGG4ZRqFUQL5UwOKMGXv3Svj4/XZoNJsPtLa3jpCTFyBFgYJgOgiD1oAh6xAmo5NbStMc9h3Grx79VfzBa3+Aq7GryBQzsOgt6LB3YNg9DIfsQLKQxFJmCePL4zjiO9LkjdwBJrjtzz3HtHw8zoBodze/0hcu8Hux0/y5Rq0JVN6NdjMblEQiiFwKYrZyAD53HlIqSYcWjwPlMqRKBT4pjdnXXYg83HFTeYw74nR2grBZE9Jwm7LoccQxEfZgyBWBlM3SKVssmwYCtoObNBqWIM/N8YFTXfUzN8dhf/jDW9RTERUzBgOfbokEAYjNRkCRTHIAhQKwezfwqU+Rj6Io9RnWJhOXbteucb66utRc1UaTsoP69X4/A5CXLhEzWiwcquiwvRPmMXvwcPfDmE/MI5KLYDmzDI+J2impYgrZYhaD7kF4zB70OnvhMbtrvqoSLCY7NEUgGgL6O4DHH2782tX21kkWkghlQnDJLkiShFwpt9JRWJIk+Kw+zMZnEclGGo5+HOs7hsXkIv77uf+OFnMLnLITOo0OwVQQ84l5RHNR2Iw2vDr3Kg55D2F/2/7Nd9q0m2Z+P/C97wEvvcT1UizGr2a5zOeDw6EG4sNhPqpuliTSetYEKu9W83rJZD19mnwAnU4V1riR+F4uh1y6jDxkmArLwLUpIgWrlXd4Pg/T3AKCb5xD7lwSeN/um3LH71hX5p0gbNaENCSNBiPeRQTTFkxGXPBFAzANdiFr9cI/uTFO3C5uOnyYJchCR2V+npf78OFt6KgI8/n4xBoZ4X105YoaL/Z6CTYOHlzdTkCS6PkvX2bVz/Q0Cd+AmuoxmbjvSqUx8HyDZcYi5P3Xf80sncGgvjcxwaE+9RQpWzcaZRF6H0uZJWg1WlxevoxgOgidRge9Ro9eZy/ua78Pfc6+lZ4zO9lLqLa3TrHM0mijyQhFURDNRtFpV3vrmHQmBMtB5EqNE5IlScKelj1wmVzspaOUMROdQaqQAhSgxdyCTlsnFhIL+MHkD+A2uZuy9bfJFIWRlJde4n2+tMSvr9nMezyfZx2GzcbfFkt9SaSbbU2gcq/aRuGEai8uHKzbDRw9qupcbNdkGbJFCyNyyM6HYc3lVA2XbBZYWkI2XYExNwn5f70EZB7b2SUrbpxSUns+N0zYrBPS8NlKON7yFsYuGjFr6Eew5zEYE5pNnc+N4KbDh4kbbliZttokiU+sffsaZ+D5fMAnP0ni7MmTvA/F6+97n6qjspV69QbSk/W+EoEAMdY3vwmcO8fXfT5iLIOBl+xb3wLOnycXXZZvXOvGZ/Phkwc+id3u3Tg1fwrjy+NIFVJoMbdgX9s+HGo/tIbEulOSL7W9dax6K7QaLeL5OLJFRlmqOwpnS1kYtUbIuq0RknudvTjkPYRwOoyLyxcRzoThkl1wmpzwWr3QaXTQSBqki+mbWgG0kTXaj+hetosXCTzCYaZ8cjlSzcJhNQNbKPCZk0iQTpdKkcdyo65iK9YEKveibRROAOp7cb+fK1y3+8ZAg9sN99529JybxIRfj6F2Kx9A14+hxGLwy/dheKAId2WZDRRDoR1LfFYqwMsvs5Bm1y6uAK4r/m+v9HenCJt1Qho+WcaJp4YRef8R5HZ1NeR8bhQ3aTQNliDXWh0vr0CqekmC2+1p/MElojHHj9+YMm2DVu8rYbWqK8iFBWaeXC5mra5d43BEZ4CFBXLT9fqd0brx2Xx4ZvczeLj74Yb1PnZK8qW6t85MbAYKFPiTfuxr3Ych9xDcJt7LiqLAn/Jj2DO88lqj5ja5cbDtIE4vnkabuQ099h5YDJYVbow/5UenvRODrsEtp5Z2wrbaj+heNEUh4BAAJZfj96JYJFgplQhSDAYG3Esl3veyzOfoDTeM3YI1gcq9ZhuFEwIB3nU3QgzdzCQJ0ugIRt76BwTfyWMy2gufMwtTaBnZSB5+4z64vAaM9AUhpTVcukajOyIc4vcTpHz723QooRAX7YODqq/biFJSPwi1g3yeOiENaXAQni2s4raKm3aEp1PHy/utuzCGI5hNebafWhMVTy115N538AlY7yuRyQA//CFByYEDBCStrWqLokgEGB/n/52dLJyLx1m4tHNfldun91HdW+ehrofw6uyrK8TecqWMbCkLf8oPl+xaSUFtxUTkZnx5HNF8FIPmQcg6GblyDtFsdCVyY9abEcqEtpRaulHbbj+ie80EObZcJiAxm1WFcNEerlLhTz6vpkSNRrqSbPbWjbUJVO4hUyoKIi+/jdxMCfKuvXBbSnyICiBy7hwrM44c4V2q16udbhslhtZavS53Ph98H3sPjk//T4wtlDHrdyC4bIHR7sZwbxkj/fPw6ZZ5fINhe8etsepmvno98U+xyJVwLMbsktu9fmpkY07LDpIEth3SoG0FN+0IT6eOl/cvKnj2uyXEMAnfMQ1Mfa6bpqp7o7Ye+VhRuErU63mPKEp1N17O1eIi0N+vpsaq39+BW/a2mwBKHrMHPptvRak2WA7CqDVi2DO8JgW1Fdl9r9WHh9zP4NyVZQSCKZgcCRi0+pVIitvkRqqQ2lZqabtWrx8RALhkFxwGBy4sXcC3xr+1bj+ie8lEGlmv5z0ulAPKZb4vNBwrFZJpKxW+J9QGmkClaVs2vx8YezmB2W8bkdePwhjSo6cti5H+GHz6ZXrtfJ5gJZPh3anXrw45bFXJc6Mud4cOwffRR3Fi7AwikhG5M1cg97TBbS2wXNkfVSs7KpXGj7tOCkI4o127GEkpFnk6ssy5mZqiE6+XGmmM09IYSeBWNBlsBDftCE+njpdXFGAs2IaYxYIhTAIBDZKOoygWJbS1cd87qap7o7Ye+ViEt9vauI3FwtNsa1Nxu3hgx2KkzTid6ufvQNHbG7J63YtrQchWZPcFSJ6ZGYZh/p8jmp1BW58eQweS6PGxoqhSqWAyMoleRy8URYGiKDedp1Lbj6jaNBoNuh3dmAhPYCo6hV2e7S8o7gaTZYJ1s5lAJZHg60LKSNz/QjnA4+FaNJ/nY3s9ntzNsCZQuQdsxSnNAD59GqYuI7JFYOKyBsGxNI67zsNXmiM5UUiTd3XxjqsOORgMjSt5NtLlbnQUUigEz8IC4EwDmiiQ0zDVY7VSW0PwVxo57johgkjfKGZnvfD5+CVra1OrWiSJAGVpiV/EUGhtaqTxct+NSQKLi8Arr3Cay2Ueo/cmNeMVYKUeMbbeOSkK8aDLxbk5fRp45plNwEQdLx9J6jEbMsHnziOabsfUaWBpLoei1gS9nvNWKFB1+FZEGjYDhuuRjwVOB/iwHhhgWXIkwltZPKSjUT6khUiusDtQ9Fa1baLljVJR9WT3M8UMxvxjmFiewFNDT2Ff6z5IklQDkiU84urAqWtLuDYlIRvvhPnxKHLyNYz5x5Av51FBBX9z8W9uuNdQI+TY6n5E9cxmsGE+MY94Pr6tMdxN5nYzlfnWW2oEenmZzwlZJpDXavl3WxsL9+JxvjYw0AQqTduCrXJKuyRIIQDFPKylNIaSU5gM2TGm34UT2muQAD5dhfOx29WQw+Qkl4x79mxODG20y92///f0pqdPq2GNjg5+KwYGeJxGCanrEQ3GxpB7YwH53AdhesgLSZIwMEAHI1Ihej0Jk1eu8ItZTSlZ5YuhAIkkv7F6PSSbDT6f1FCI/8wZ4CtfIQgwm3kq8ThX3VtNhzTiZ+phtsuXeW4Gw2p8EYlw6peWiCWLRZJF+/p4+da1Ol4+V9QiX9QgW9Dg7Fwb0stZuLpLMHq46fIycerMzM0HKrXFayJCUl28th752GZjMPHqVf594ICqG5FMEtSaTNzn3r2s+KlOG92horc7WJevWj3Z/Ug2gqnoFEKpEPwpP6aiUzg+dBwjvlGcGfOtAslWuPHo0CFMuqZwcaKAF16LQLP7JGS9EQ93PYwOWweypeyKEu4H+j+AxdQilrPLaDG1YNQ3Cq1Wu+EYGyXHin5EyUJypQ9RtSULScg6GQ5jozLNd69JEpUDXn+dz4PBQaZ+Uik+KwoFrCw+PB6164XPR6rdrbz3m0DlbrXr3iziL2D2og2+Tgsk6/Wn7/w8kE5Dyufg63BgNuFEpFyBR5IY/UgkWJd28CCf5CYT/3/88caIoVvtcvfMM0z2f//7BBeDg/TmqVRjhNR6IYJIhOBqbg7y9FkYCyZky/tgva8fbrcbo6N0QqEQD1MsEoM9/vjq5/WKL85GgEvXvfl1oILWVpj6BhHMuzcM8Z85A/wf/weP5/GoavDxOC8H0Hg6pBE/s1la5/BhFV9EIsSJoRAfPJkMt41GgT/+Y+Bzn9tAQ6XKyysWKyJJPaJJHQplCRfnrEinAJ8rB8miBTRqNfL0NMdy5MjNS/9Uz4EsEzMvLgKvvkpdiA98gH2kvN765GNJIlaemODldrmARx9lVOXSJUbm+vvVh7PBwGu6E5qIN812tC5ftVrZ/Ug2gtP+00gX0nCZXBg0DCKWi+FM4AyuLsaRvvwM+nzOVXPjNrlxf6cL3XISr17RoFN/CA8ODSFdSiOWi0Gv1WPQOYjvTX4P//3sf0eykEShXIBRZ8SwexifPvJpPDn4ZN3xbYUcK/oRnQ2chcPgWBVxqVQqmIvP4bD3MAZdjco0393W0UEtxq99jSDdYOBts3cvv1OyzOemaH5ut/O9W33vN4HK3WhV3iwX1CF/YS9Me4zArkE+Xc+f58PJ7YbJlkcwKiEXDQLmOOPcBgM91dwc7zyRgHz00cYeZFvtcie0Ntxu1QuHQo0TUmtTEJEI8KMfcfyVCtyVInoiZzDxQwlDkTlIxx6D2+2Gy0VMduUKv2wf//haXCXLgDEbQ/biOVjLcXogo3ElLZYNpGDsPwJZdtYd2uIi8Gd/xhVJdze/0MUiV+WilY0sM8KwWVSmET/j9W6eqpqY4CXOZIgVBVjL57md0UjsNznJsf/u77KyZY1dLzHyvzmPsUo/ZpfMyBU1GJ+zYnzeggPOeWRdTpSKJugyPM9YjDg0Gm2caLrVTEU1bhW3VDrNv71e3iqvvMLrcPz4+uTjSIQpqpYW3qr5PL8+IyO8LXt7+dqZMzfOob7pthOtHtaxatl9RVEwFZ1CupBeAS4VpYIEEuiydWF6Po3FpQXs6XMAWH0cSZIgm4FMrgybphVjwTEspZdQrBSh1+iRzCdxcv4kMsUMhluGV8i254Ln8MVXvggAa8DKVsmxoh/RXGIOF5YurAI2c/E5eMwefHjPh+95Im21HT4MfOEL/M4I1wHwPjcY+AwVruLxx29PI9kmULkddiOMyxpvJlvsMM4akJ0OwXrhPOvG5uf5/sICsuPzMBraIFuLQHs7j1Us0sPqdIx5m82Mcff2NjaG7Xa5265qlSjyF0nU11/nt0mWAZsNklaLkdIMgqVdmByrwCe/A9OT70E2JyEUYorj8cfrC5u5XQp6cpcxEZQwdMAHSfRLMZmgGGX4L2Qx7LsMt+t+1D54FYVf7vl5nobQbDEYOC3RqPpFF6e8njXqZx58cHNl2miUx5+cVCMp+bxKJp6f51xYrcAbbzCy8m//rSoeW71Df+dRPPu3dsTCOfi6yzA5tcgmSnj9ghmvJnrgUcyQUyTZajSMXuzZQ8fv929+mbeTqRC41evlbZBOr54Pr1fVRhG+eSPysde78S3p8918gvQN2060eljHqmX3K0oFS+kluGQXOzlXyitAw6AzoMNpw9uFBVwJ2tHZ4ljhgiQLSRTLRYSiGWQrMVxNXYRSXobL5OK+i1k8N/UcopkovDYvbAYb9Br9CuC4uHwRXzvzNby/7/2r0kDbIcce9h3Grz3wayupovnEPGSdjMPew+8qHZVq6+gAPvEJRiJnZvi9ikb5nSyV6DpGR2+tyFu1NYHKrbYbySHX8WZupYKebgUTp3QYOnMSklLhXaXXQykU4Y84MFy6BPeQgZ5ElDSIp61o6tAIN0XYjXS5245qVSxGr/v22/S6Z87wmC4XkUChAJ8jh+PdAYxdsWL2HQOCHWkYPdZNV79SNIIR0yUEvcOYDFjgc+VhMpaRzWvhjxrh8ioYMV2CFB2E4vascliKwjSH1crTLpVUrQEhMpfJcIr7+jYmXlY7X8Ejqa4eF35GrPI3U6YdHuatNjPDKbNaCZiECGxvL4FVpQK88w6VWT/2sdXzpCjA2EI7Yt0yhjovQ1peApaKcEhO2B3dCOVtSOb1MFS4faFAgHDtGvFkqcRzWO8WF5hbSHQLEuv4+MaZCpGuK5UIxITwsTCjUY22CN+8GUbe6JbcKaG1m2o70ephHauW3XcZXYjn4ghnw0jmkyhVSkgX0uh19mIpvYSlwjKCOhNePKegf6gMs57jyZayKJSKCM7ZEDK+CSMmsde6B7lSDulCGqF0COliGgadAflKHhqozxSNRoNOeycmIhM47T+NB7rURqvbJcce9h3GwfaD73pl2moT97nHoypY3CngvAlUbqXdaA65zqpJkoCR3giCf3UWk/luiquZrcgWjfBnzXBZlzBSOgcpWCJfJBJRWYcuF71Uo9wUYTely906JhRz83l6QqHpbDRyztrb+W1yu+GzJnFiyI/I7BnkHjoE+cjezb9guRx8chTHH4xibEbCbMiEYMwIo76C4a40Rnqj8CWi8M8UMHZqNb40m9XS1VJJDTCJ4+n1atVIX99qHFgbVMtm6XQXFpgbrqLJYHCQeDAY5GcNBm5rMKwGM4BajdLby9XRG2/w9iqVCCIMBl4uIe5ksXBc4fDazMDK7bbHAclyFEgmoRSKCL4jwxYxw1CQoNNxNZZKqbfym29yzAcOMKVU7xYXmHtmhmBpclI955YWgqr1MhWCOiMAnUixCRPaEDbb6kjWXQE4tms70ephHauW3b+4dBGz8VloJS2sRisUKLAb7Yjn4vjmpW/CKTvRvXsXrLNWhOYU+JW3oDUWsNt2CEqqGx7XMgKOMczEFlGqFFGsFFGulBHJRpApZGA1WCEpUm3wElaDFYtJEmyr7UbIsRqN5p4vQd6u3WnflSZQuVW2EznkdVZNvuhFHM9/G2Oeo5gt+BBMt8FoKGLYfBEj6Vfhs6WAREHVR5Ykpn2KRXqpRrkp1XZTutzVWPWcvec9/Ht+nuMXIG9ujp4tlwMuXYKUycCTSABj3wHcWQC9Gy8Hrj/gfaYYTowUEfHnkcsqkE0S3D4jpEwa/pALz75qQ6y0Gl9OTqrS62JqReW1TseURDjM6MaxY/VbLQnQoyjMD5tMjKpU0WQQizHgJRxyMEh86HQSeLS2Eq+ZzZyeI0f42elp7i+fV6tifD5upygEFzYbx9vRQT51by+3cbtrbjdJAux2JBPAUhoYHOL4FxdXR06KRUZFrFbeFlYr91V7i0ciPF+/n9tXU4MWF4lxT51aPR4xf0Kdd2xspc/lyldCUXgNOjt5De7YEuKdtp1q9bCO+Ww+PD34NGaiM6iggkK5AFPFBIveAqWiYCG5gKXsEpbSSzjis2L/w3P48RspFGasUBIGBAoFHN2ThnsghHhYi3eWEkiGkxhyDcFutCNVTKFUKSFbysJmtEERamPXLVVIwagzosW0WsW4SY59d1gTqNwq24kc8nqrpkQCPvhxwv06IkUbct4+OtrsAqTJJFAEn+b5PNmD7e2qqs9WuCm1dlO63FVZ9ZxZrUyS6vWMAoVC6hwUi8yxCNUuRSHZdmyMY7zvvvXzP+IB/+abkCoVeERdXqUCOBxQ9AaMmT+CmN6CoV2r8eXBg4wIxGKqCrxez6Hkchz+wADwK7+i8j/Wq7J+8UWeUmenqv8iBOsWF3kqopRQKM8XCtzPhQucAoeDgTKnk6XKAEt1l5cJWjIZFjUBBAfidjKZOM2C79Hezinp61t7uxWL/GlvV3X6MhkeU4Auu51Rm1SKlVAiylR9i2ezfK9U4jmLeRUlwRcuEDhpNGrljriEQp03EOD8BwJ8v1BYLdETCNyhJcQ3w7YiWbyJradHYtQZ0W5tx4eGP4RLy5cQyoQQzURRrBSRK+dg0VkgSRISuQS+n/0aIu1R6OwtqBQNSJs1aD38frjNLhSXinDKTlQqBDwlpQS73o4WcwuiuSiK5eIq4bdKpYKFxAIOtR/CqG901Vib5Nh3hzWByq2yncghr7dqul65IyXi8LTLgCN1ndVpV2VK7XYyMQ8fVhXAJidv/El+g5LwGxKL682Z2UxvPDPD98tlvu9yMXwRDvOch4e5X9G0Zb3UmiTRU/7t3/Kzbjc9bCgEhMOIyJ2YHTgO3+MxSNLq0LJGw2f/yZMcQnc3gUMsxveGhwlSjhxRT3U9OXe9nqeVyRCYuN1qhKFQ4LbJJE95ZIQ8kB/+kKW0uZxK4t2zh+LDySRP1+MhS//ZZwleIhEer7eX022xMM2ytMRbZGBAbbwXCNDp+/3qeIVQWi7HaWprI6AxGOgTL1/muHU6XpJQiGOx21ff4tksX29pWe07k0ni3myWQKi9nSCoNnUkOCcGA7u/vvMOz7Wjgz+RyB1aQnwzbQdaPWykR9JqaUWhUkCLuQVO2YkLwQtYyixBq9EiX87DZ/FBq9WiUC4gkAogWUjCbSqiqCtiKZ/Cty8n8L7e90GBArPODL1WjwHXAEx6E3QaHdwmN56/9jyiuSji2Ti0Fi1ShRQWEgtwm9z49JFP19VTaZJj731rApVbZTuRQ15v1dTerpIYdu9eLRbhdHLp2t5OL1Sp3DwxiK1WM21GLK6es0KBgiDpNEud9Xo1nAHQY6XTPKcjRwhohHc/eJAes15qTVGYX+nupjcVLQZsNmDvXuRSDuRngzBdPA1YRtaAuo4OOvH+fjruaJR/9/UxAlJdSbOZnHtvL6MfbjdPJRbjafb1cZt4nNvMznKYIpLjcqlE1vFxFVBcvcp9DQywNPu73yUI0Gp5u/T0cHricZW74nTy8yJV09rK18TtZjbz9r18mcDA6eTxNRr+iOoik4lTG4tx7MDqW1xRON3ptHpMRSE4isdVsTZZXj87Khowj4zw1ggGCZAk6Q4tIb4Vtt3KOmyuR/ILB38BuWIOl5YuIVVIwW60o8XSgnwpj7nEHHLlHKSKBAkSJElCvpwHAFgMFmg1WkSyEbwy8wrMOjOymiyi+SjKShkWvQWFSgEmgwmPdD2Cq9GriOQjWM4tw6gz4lD7oQ11VBRFQbejG5898ln4U35IkgSH0QGX7EKhUkA4E96wJ1HT7nxrApVbZTuVQ15v1fSRjwD/8A9cand28ukuajS7u4EPfpBeaXm5/irrRpvUbLWaqTYHYjQyP/H88yQv/MIv0Mv39ND7xuNqHaogV1RzbaJRLu/37FH1XUT5hyBn1EutCfQwPMzjdHTQ++t0gMkEOaqB8XwZ2WAcVtEwqGpeslkeVjjPjaavETl3g4E4zGBQyaWSpGKyVIpFT6J7qdOppnEKBUZHcjmWEQolWrudp/TBD1IQbXaWok1eL8urCwVOiehoAKhAIBYDHnuMl0ZcWiG9bTTydspmCVIEcBJcGkFq1evX3uIiLXbtmoqZ43FGiMT+HA6mf+67T1XErHcJvV7g/e/n50wmVXiu3u17s3ox3YoeTw3bNpiQjeiRvHTtJVSUCgKpAHrtrPKxGWywGWwolAu4FrsGo9YIs84MjaSBSWtCupBGXpOH3WhHm7kNs4lZKFAAhWkbEQHxWr3odfZi1DeKilLBsGcYRaW4Rpm2tilivpTHmcCZVf2HrAYuBFOF1KY9iZp2d1gTqNwq20oOuV5H4uoc63qrpgcfpMTgxATzB0Yjtb8//WnG/9d7ktaCDCEEIlSvGomMbKWaqTYHcu0a8ycLC/SahQJLkX/jNzgnU1OM7ft89Lzj4wQmPT30Ulot95XNqvXBwGpPWZ13qPYq0Sh/Wyz07GL8AMXkSiH0FLSYiD+IoWAIkvD8WO18PZ7NHVOjcu4GAw+hKAQely9z+4UFNRXU2qryMxYXOWSNhvsXenyCTyLM4+F0Go3c9to17n/PHmbvajGymDKnc+3tls/zEj77LC+Pz8fOCIcO8f/FRY6zr4/zMjm5+hZ3uwlAcjne7tPTKh69Xl2/0jDw9GnSk0TQUGRHN8LGO6XZ0oiJHk/XrhFLC1Xb2ojaZnY7wU4jeiRvh95Gv7sf7dZ2hHNhVFBZKSWWIMGkMyFZTCKai8KgMaCEEjL5zEoFT1kpI56Lo6gU4bV48XDXw6iggnA2DKPWiH5HP6L5KIY9w3hi8IlVERBFUXBx6SJOL55GMB2ETqNDvpRHIBWAw+TAHs8emHQmLCYX8d3L3wUk4FjPMfQ5+lbJ8x8fOt4EK3ehNYHKrbRGcsgbdSSurqSpt2p68kkuLU+f5lK3pYVPeJHXrbfKqgUZ1/vnYGKCUYX77ycAGh2t/zTfTjVTdQ7k2jXgO99RCQsmE73nhQvAl74E/OZvsuJHaKjMzHDb/n5+PhDguTqdDDfMzTGcABCEiA7N6bQaYTl7VvVWovFNNru61jUQACYmIIVCGEnZEFzSYHKmDT7XNZgeOrSt7Nl6QTVJWi3nDnBIFy+yikeoyQoxX5EmyWb5W5J4Ku3tahny9DQxpk7H6SwW+Xc2Czz9NG+puTkea9eu1Q33hFWnaurdbj4fL8MPfsDpHRzk5SsUeMnLZQKOeHxtAE+SmKETPYgMBjp1cSy7nUBFRG2mptTKJ9GeaivYeLuaLZvZ2bPAX/4l1Y+Fuq0gFL/+OuXJGymA8/v5tb10SQU7e/eu/7XbaWtEjyRTzEBRFDzU+RCmY9OI5WIIJAMw68yQNBLcJjeiuShCqRB5KHozumxd5LBcTw+VKiX0Ofow5B5CppSBS3ZhwDmA2fgsXpt7DY/0PIIR3whquza/cPUFPDf1HBL5BDwmD3w2H6LZKBaSC+hRelBwFmDRWxBIB2DRWwAJCKaC6LJ3wWqwYsg1hMnoJMb8YzhuOY5INoJAKgAA8Fq98Jg9zdTQHWxNoHKrbaMcciMdiTd76mm1wAMPbLyNsHqRje9+d0WaHvk8n+JTU1zWf/KTa5+a1aADUL2iELKoF68XORCjkZGUZJJeVTwoHA6ObXmZoO1zn6NXEwq1Q0OrUzDRKAGWx8Plrder6sUPDHAbv59hiFOn6FGqS24mJig4Yrfzc/E4/89mAa0Wvl4Djuvewdi0H7Mv6hEseWAc7GqIB6EovJwBPhPR27uxnLtOR3KoqORpb6cDTyQ4ncvLBCKCE1KpqJ2RnU7eTvE4p8TpJJclkeBpZjJq35r5eU5lKMS/3/Oe1UBERIt271Z51y7X6lW+JK3ujHD+PKNCySTPq6uLQKaeoqXfzxRWOk1QdfEip1+vJ9jSaIhJy2Wemwh8HTvGcQiQ0gg2vhHNlo1scZEBTDHH6TS/fuLvdJrH/sIXNo6s+P3AX/0V56BSUV+fmFj/a7fT1ogeiVlvht1gh0lvwtGOo2i3tuPV2VdxLXoNsk6Gx+xBMp+EP+2HRtLAZXKhw9YBk96EZCGJZCEJnUYHh+zAgdYDiOfjSBYoGmfQGWDQGrDbvRvhTBjhTBheqxeFcgHPTj6Lk/MnoSgK9rfuR6FSwHRsGgvJBezx7EGmmMFUdArDnmEspZfgNrsBBQhlQkgWkrAb7ZAkCT6rD28H38ZMbAYXli4glA4BANot7Xio6yE8MfBEM9pyh1oTqNwOq7c8bbQj8cGDN6f8NxIhSJmc5HLOYqHHSCTofdJpOvqf+7nVT3MBOrJZLgdrmvqhr08V8hAmciDT08xn1JZ+lEr02J2dqpZzby/Bg8Gwmn2p0ajlKyYTjz89zTncs4fbi87QAL14tXez2eilv/c9IohSiXOSSnGf14GkLxfGiQcVRBIvIleOQP7o5+Fu0WyaEXvhBWKxEJ+JaG/nsFpb6Wirg2qdnVxVl8s83Z4eOr6FBf4cOaJyiINBnloux21EpU0splbY6HS8dGazSoJdWCBP5dgxXppSCfjxj4Fvf5vZQSHQ5vdziqJR4N/8G4KnX/914uRacObzqdGRjg4e+8tfZi9Kl4uRBcExEfMigEZfH+cin1cv/dISgV1LCy9BOs1LYrNxfNHo1rDxepotuRznB+DX78EHecxGUjCifcLkJI+fSnE7rZbHiETUlNcrr1CeXHzlqvcL8B55/XVVfE9Ue0UifL3e126nrVE9klHfKK5Er2DINYRueze8Vi+WM8vQQININoIWcwsjL1AgSRKiuSi0Gi1SxRR0Gh0kSUIgFcCl5UuwG+2wGqzosndBI2lwauEU/r+x/w/pYhr5Uh4u2QWrwQqL3gK9pIfT6oRWo4VJY4LH5MFkZBKRXAQ99h4spZfQZm5DsVKEUcuoaCwXQ7FchKIoSBaSCCQDeGXmFeg1etiNdvQ4egAAoVQI373yXSxllvDJA59sgpU70JpA5U6xrXYk3gkTIEOWgbfeYiTFYlGBgF7Pp67IH5w8yRi5EA0BVFnVixfXKnctLNDj9PevrmYSOZDnn2eeoJpdKpTIPB4eZ3mZxxZclQsXuC+NhqGAQIDj6+ujh37Pe0h+ECArnycK6Oujtko9HRuPh+q8b7xBBHD1KsGh3U7vft2zSB0+eNpKgP8tIDYFtK5/HcQq+fXXOY09fCYiFCJQeOABpmBEFERECRYXeUivV52Wjg463vl5TmWxyCEJHofQU1lc5LDvu4/T1t/PiIjAfZcvq4BgcpJTt7TESz4zQ6x2//0EU62tfG9xkRovy8sEH7/8y2tTJYrC6IjQD/wP/4Gf/cd/pDru3JwasQDWZgorFV4Ck4mXV6Ph5Uok+FOp8Pbv6VFx7VawcT3NlmRSPf9wmKmboSFybBYWNuexRCIqx0c0RBSEaI2G/0ejfF+k8aoJyWK/vb38Wun1vM7VejIdHfxMva/dTlujeiTt1nYsZZcwGZ2EVW9lA0HPMKK5KLocXeh39uO0/zTmE/OIZWMIlUMwaA0waowoVAowaoxwGB3wmD0waA2I5qKIZvkzFZtCi6kFkiQhW8hiKjqFZC6Jbkc32i3t2Ne2b2W8eq0eNqMNkUwEnbZOFCvMmeo1elYbKdwmXUzjauwqQqkQJpYnMJOYQbetGwOuAaaIAPQ5+7CYWlzhwDyz+5lmGugOsyZQuVNsqx2Jd8JEZGNpifuuVOglxZe0VFJrWcXT/uxZLp/FMtPl4riDwdWRIJOJS/7XX+f/y8tqHasgFp8/r5aqOBwqwUKW1c5yormhzwd89KP0Km+9xXmoVLhdVxef9JOT9FLPPMPPVS9dFxc31rHp6KCXEgxSu53jF9Evr5fXoFTa9DooCiMjFy8SBFQ7oL4+DuXSJeKnZ57he+EwnZjbTdBQLQtvNvPwgYBaMVOpcHpiMeLDjg6mWIaGOBUvvcRpEX0hhVaKKH0+c4afEaqvHg+Pq9UC730vHeTSEnkS//f/DfzO7/D4//W/Ap/97OpUSSRCCtH0NMGZSFOdOMGpFB2NIxGOpbZE22Yj4JqcVHktXV3qLbi8TP7Lnj387O7dW8PGtZotySS52cvLnEcB9P7mbwjW9u7ltdmI95LLcR7zec6ZruZJqtPx9VSK5/V3f8frKCJOYr+nT6vnVE8Hsq2N74sI0820RvVIjg8dx5h/DOeD5xFMB9FuacegexCDrkHoNDosJBfQbmmHP+XHQnIBTtmJbCkLl+yCrJNhN9qh1+ph0ptg1Brxo9kf4Wr0KnQaHSLZCFVvdSYYdUYUlSLmk/NI5BNos7ShzdoGADDpGFWZjk0jU8hAr9FDp9HBqDNiMbEIo84Ip+zE+PI4MsUMjFojkkWmryCRPDzoHoTNYIMkSXDLbkRyEVxavoSHux+Gx3wH6cc3rQlU7hjbbkfijWyzGLaIbLzxBpekGg0/Iz4rgJNGQ69VqbAE+s03uRQ8eJDbCmWuQED1GnNz9F6JBMMLy8tc6gtSsM/HEuS33+YyWlH4dBegwGLh69XNDTs6uKQPBDjeoSGGJIQkaW8vj3/27FrCgQBlmQyPVdv1L5vlNiMj9BoWC9/TaulZxL4auA6RCIFIpbJ2ykXFi9jm4Yd5yiK4JVbm1ZhKkui4RTfgSkWV6C+VeDqin1BPD52fqCQSJiqADAY6vkxG5S4DPB1Bxn37bU6naJCo0QC//dvA7/0ep/4v/oJT8NBDKsD5yU+Al1/m9hYLb42332YQ7OBBVZIfWIsXBZl4bk7lt4ixplIc5+AgHX0opGLQetjYaORt4/OpXyOTSdVscTgY4VhYUIvBxK0XjxODdnSonbDX472IbKPBQLAkxissk+H+jEbi8VCI+L6lhfsU+/3xj1Ux5TvBGmnW57P5cMJ6Ars9uwEAHpMHXqsXkiRBURS0WlqxkFjAoHsQbpMbezx7MB4eR4+9B+8sv4OKQiJORalgIbmAmdgMMoUMTNcbGNoMNpQqJeRKOSiKglKZjQ8vhC5gRDsCg84Ak84El8mFYCqIicgE3CY3zvjPIJwN41rsGsx6M/pd/dBKWrhNbiwkFvi37EabpY1E4FQAVpcVkiTBqOPKIF1MI1fKoWl3ljWByp1iN9KRuNYUhcvNt97iE1Kn45O1NoYtIhtTU3T2Op2qUZLL8clrMvHpLVRb43GGBL77Xb6/ezff6+zkmNNpPtXfeYdP8M5OegSHYy0puLOTJchf+hKBTGcnn+SpFL1NveaGsszlssNBrxYKqUvwgQHVE9eKbbjd9A4//CG3F0ClrY37i0Q4/6Oj6nXwerd1HcRqG1jbMK/6tXRadd4CR+l0BBgLC2oFDMChms2cJnHp9HqeksdDPPj976s8C+HMRRm0qNKOx3mqNtvqKICo5O7sZGREpJKqGyT+7M8yYhIKAf/pPzGt43YTpPzwhzwfs1l1yDod8e3589xvLKb2Maot0Xa7eSvOzfHyizGKyyoEgwW3RPREqsbG+bwKsEwm/i1SSkKz5do1AitJ4uu5HMcpQIfFwhSZKIcWc13Le3G7edvY7QQl0Shf0+n4/8IC/zabuU17O9NLwSDwyCNqOfvQEIOO8/O87WrllUIhftbrXfd223FrpFmfJEkYcg/hYPtBTIQnVr3XbmnHfHweF0MXcV/bffCYPChVSgCAPZ49sBlZQRTLxTATm1nhs5QrZThkB3RaHQyKAdlSFnqNHpliBhVUsJhcRLachVt2w21yo1wpw2VyreilZEoZeMwetFnaEEwFMb48jm57N2SdjG57NxQoCGfCKFVKsBqsiOfiyJayMOvNyJeYE7XoLZB18przbdrttSZQuVNspzoSCwbnd75DryQiFILvEQhwWSjAikipLC/zKbq8zGW1yAeIz4hQgMlE7yWWoNPTfKILcoXPxyX99Y7GSCTUjnUHDvDc/u7v6LkKBYKn3/gN4O//nrHw5eWNmxuK6NDDD9Mj1EZGyuX6rQgEISGZVAEKQJA2Ps7wwMgIQxM3eB3Eahuon20SPBHB1QVWly4PDNCpi/Jngb1yOXW1392tOuZEgq8FgwQA//SfEmdVl0GL9Mr4OLfv61vdyC8S4Rg0Gh53fl5NOVWDgGeeIUZdXiZw+X//X+CLXyRIMZkIUqrTOk6n2vX52jWmVdbTPRQ8lHyeVfZGo3pZqzVrRA+kBx8k6AiFVBXfri4G1oTwnZhbodkC8D2zmbeO2L/Tqd6y4TDPtTpoVtvhQpJISD51irchoLZOiMfVFgJuN2/J+Xmew+wsj//007yV2tp43snk2tYJotG5iFzdaVbdVXkyOglZK2MxtYirkatYTCyirJQRzASh0WhQrBThs/qwv20/XLILyUIS09FpTEYmoYEGhXIBZaUMQ8kAk0RJfaPWiHw5j3KljFwxhzZzG3wWH1LFFN5Zfgd2vR0HvQdxsP0gdrl3oVQpkbtisGE5s4y/ufg36LR14oHOB2Az2HDafxqnsqeQzCfhMrlQVsooV8oUkctFoJE02NuyF26T+3ZPbdNqrAlU7iTbTkfianG4fJ5Pzh/8gE9Ng4FP17feoifbtYvAwmBYXUbQ0cGmNHo9Y9GZDJ+W0Si9g1bLZf6RI9yfEO1wuei8Ewk+hfN54LXXOBYR447HVeKrSD+9/DJfczpVVuEv/7IaL9+ouaEIPeRym4t/CBP1qQCJBlevqgxMq5XeoKVFXbbeYGdot5sOeWKCzqaaoyJAgSSpFTYiWCX0ACMR8jEWF9Wohoh2iI4JAmS0tKgdBgIBlZwr9nXuHPctgMr582p3Y6HFcu0aoxXptNroT6fjbSKiOiLbtbBAvvKpU7yVBEHW4+HtJYSCRdBK4MJ9+3irRKMb6x4eOKBK7/t89Ts+GAxqM8XRUR6jGq8K7oi4Baq1FlMpnocIWpbLvI06OnjepZL6mdrbSq/n+fv96i366U9TR+XyZY4jnea1sFrV3p+iZ5LFwn3MzjIK9eijPJcDB3jcmRmVxwNwfA8+yGqsO5Xb6bP5cHzoOF64+gL+fuLvsRBfgCRJsBqsaJfbUalUYNQa8VjvY8gWyVORJAmlSglT0Slki1kYtUboNXooUJAr5VCulFfUZbOFLLQaLWwGG4w6I1wmF9qsbTjcfhiZYgbZYhYd1o6VEmRhRp0RPitBjSRJ0Gg0GHQPYiG5gInwBBaTiytAaDm2jJJSwoOdD2K0Y7RJpL0DrQlU7jTbSkfiWnG4QICewGgksAgGVQn5eFyVNI3F+OTev1/dV0cHWZJ9fSwzEGpgLS18kg8Pq1EUURcrchzFopqyyWR4PLHMtFj4xM7l6BGLRT6NRaVOLVtxvYomAchiMbVmt5aBqCj07B0dqxFAbRdmt3u1d5MkNScilq430BlakuhAL19mWH96Wg3giCZ9oq/iN7+5urKkWg/Q41G5I4ODLHO9dGl1OkmS1LZGbjenKZfjMPV63hLnznHb1lZW9bS20tlmsxyPyA6Wy7x0giO9vMy/HQ61v2M0yun/5/8c+I//UR3HL/4i91kqqQ5b8LCtVkY6BF2qs3Nj3UNgY01ERVkdlanGq+t1oxBaiwLUXb1KoGO1quDObmd6xutVq9nFPt98k3P54x+v1WH8zd9UlWn9fu57N+kbK1+XcFit+hf8cVE1f/Ag1wBjY7dP8G09W6+TcrV5rV4oioJyuYxeZy9azC2wG+xIFBJYzizjfPA8WswtcMkuTEYn4bV4cSV8Bcl8ElqNFm2WNpSlMmLZGErlEiqVCvLlPErlEnLlHBwGB/RaPQ60HcBjPY8hU8ogmA4ikA5gfHkckiShz9GHAffASjTEZrChw96Bt0Nvo1AqAEbAbXLjsd7HYDfY8fri68iX81jKLDV1VO4CuyOAyn/5L/8FX/rSlxAIBHDo0CH8yZ/8CR5oVLTsXrRGOhLXisNptao8ZqVCh55McluDga8Jou7Vq0wP1apwiS5vx4+roOcHP6Cn9XjoNYRymaKo4Kenh+AgHldb62Yy9KDt7fyt1RL8aLV8Ore28u+NFGyrz7UakCmK6pGOHl1dRhGLcUzCw/X08LzEErtadEMwXctleuuqdJGiAJGoBjnzLsjurcuZ+3wU6mptJe6bneXrVitBSkeHmn6pxWpCDzCbVfvXyDKBjciqmc3qsRRF5Ui43ZyC11/n70cfVQuVLl7kT3s78dzkJD/vcqm9drJZNdojuCQC1NhsTEulUsBXv7r6fL/2NY67p4fjKZfV/j/d3QRC1Q0JDQYWWe3eXb8/z0Z99bbSjaLWZJnRqmvXVL50KkWAIMscp9OpRluyWYKUN95Qg5L1dBg/8QmOV2jE2O183+1WibzRKM9bo+G+Ll5kVbwAYD4fM5p3RL8gbNxJubojcTgTxqmFU7AarOhz9iFVTOFa7Bri+ThKlRLiuTi+P/V9/MbDv4FMKYOLSxcxHh6HzWBDn7MPiqLAbXZjIjyBpcwS0oU0FCgwao3kjBhkGLVGSJCQKCQwFZ1CupCG2+SGRW+BJEmYT84jmotitGN0pQFhh7UDM7EZzCfnIetlmHQmGLQGllG7+nGg7QDaLG1NZdq7wG47UPnGN76Bz3/+8/jKV76CBx98EH/8x3+Mp556ChMTE2gTy9DbZXdUp7EqqycOFwzyydrSQmAhiAuirKFQ4NNVUeikz53j50XNY21/IQFi5uf5FBf1s4IFKVrlarUqILLb+ZNIcHuDQZXvVxQ+rfV6ertqdmA9tqKw9dR6L19mHsNopOfP5egVHY61CGBqSlXYFSUWIjYvCLhV6aLt9oSpvV283tW4T1FYCeP30+FtpKhaKPASVY/BaqUTnpzk9qLnTjTKS202c5zXrqk6JQCd6eQkL7EgkXZ3cxwiNSO6Hnd1ccoWFjiNly7xFuno4HbJJMXfEglepi98gZdnfp6icT/1U7x1RCGWzUbSaSDACEQ+zxLgzfrz1GoiCkXZ6uDWZt0oaq/N2Bg//8EPMjIyN8dxCmE7l4tzPzjI7QRPOxDg/B49urEOoyDZzsyohXQiRTU4yP3MzvI6arXc/tFH78wOz5t1Uv61B35tBawEUgGE0iH0OHqQKqYwFZlCrpSjUJtWj3KljOnoNH48+2N8duSz6HX0Il1IY8A1gIpSwZh/DEuZJfQ6e6FAQVwTR6FUgNXIipxWUyuO+I6gggpOzp+EWW9Gh7UD2VIWTpMTxXIRnY5OBNIBXI1chauD5V65cg4fGPwAXLILc4k5BMtBGLVG7GnZ02xQeJfZbQcqf/RHf4Rf+qVfwqc//WkAwFe+8hX84z/+I7761a/it37rt27fwESnselpAgCDgY7t6NG1kYhbbfXE4cR4CgU+BfN5VbNElIjk83T4e/bQ0whxho36CwnG4KlTfL2lhV6wUlEjIno9l6W5HJ+6g4N8UovUi05HTxCP00M//PDaFEotWxHYWK33/vvp9Uslskdfe43jqIcAXn6Z7wuZfVlW+TACGN1/P+B2b7mHjLDNwE1LC0/j1VdXc1aEVWO1ixfViEi10v/UlKryLyICZjOn2GwmsOjvV3XtolF+RrR+crm43ZUr/D06SvqS2azq9gmOhdCAicdJTnU4+PfXv06w4vWys8H0NKvM/+zP1ABcNMpboKODP5EIj93Zycqkrc7tRrfnRpGXaqvN/j32GIGPaCXQ1sZz/NjH+PUW+1xYIKjZtasxHcbqQjqhTehwqBVABw5w/2Yzb93e3tX3j+CpiK/SsWPM0N7Kx029TsqKwghHr70XV6JX8HeX/g4H2w+uSgMpioJAMrASfQlnw8gUM8iX88iWsjgbPIsXr72I40PH0W5th16rh9VgxWjHKK5GrmI8PI5ZaZZ8E1nCsGcYeo0eBq0BXqsX0WwUl5YuYdgzzKqhfAzDnmGUKiUE0gGY9CYE0gEEUgGkiim4ZBeeGHgCXqt3VcdlEXFp2t1jtxWoFAoFnD59Gr/927+98ppGo8ETTzyBkydP1v1MPp9HXpRNAEgkEjs/sLNnGdu+elXteQNwWfYP/8Bl44c+tLXWqDtp9cThLBZVvM1sVj2OUJ7K5/m3IB2I+tlG+gt9+MOMXqTTak2rEJ8wGtW0kMPB/71ecjwuXuRnBHelq4vlDqL/TrXVI8Fuptbb06OqYcVi9RFAJMJxJBJqubFoyKLV8v29e4EjR6BA2nJ/RaDxBnlCK2U9zTmTiafy1lurxxCJcCrm5ug4XS5OoShZNhpVDO1wqKqtZ8/ysubz6qkLtdeODoIas5mYvLVV1XCRJIKZM2fUgq1gUAUpra3Av/pXqrrtM88Af/AHFIULhfi5Q4fUEtzhYXIwzpzZ+tzuRPsrYO3cu93Epnv2qBJC4bAqyiyiOX7/1nUYq7UJL1xQm3p3dRHAiaiY4NGI+2dmhl/fq1dVsPLNbxKHf/Sjty7yUttJWcjPx/NxlJUy8qU8Xp55GSfnT+LRnkfhtXpXSpKTBfJOgqkgCpUCZK2MfCkPp+yEFlo8N/UcjniPoMfRg4nwBIZcQ3Cb3HB1uNBqaQUUapl4LV6Mdo5C1so4EziDqegUItkI/Ek/AECChBZLCw61H4JTdmIqOoVgKohgOohwNoyD7QdXRU1csgtT0Sn4U35EspG6XJum3bl2W4HK8vIyyuUy2tvbV73e3t6O8fHxup/5vd/7PXzxi1+8eYNaXAT+y3+hYzYYuBQVBFFZ5pPE76cX+vSnG3tK7rTVE4cTfJDFRbUFb6HAaJAk8UkstNGTST712tp4rpv1F/rsZ7m0E/KmmQwBSDisqtfa7YyUhMMcQ6UCPPUUn8Tz8zxWZyfnU7T8FbYeA7JRtd7l5foIQFF4DrGYykhNpdTtczm+bjQC6TQiYQWzs1Jdlf31slNbaR4tCpZqNUSEZbOczlCITk2AlB/9SO0TWSxyDEJyXQATsZ3Tyf0sLvIStbTwkomuy6IQK5VSb4tUSs2AiVupp4f7LBR4Dj/6kdrZ4BOfIO8mGOSUT0+z/Pf3fk9VsP3GN1ghPzi4ls/c6NzuZPurenMvSSoRV4ggV+NkYPs6jB0dwL/8lwQaQmaotZW3nGjwWE0cnp7m65OTvLYiMzo/D/z1X/M6/LN/dus7KScLyZVUjtVghU6jQ16Xx9XoVfxg6gcYcA3Aa/Xioa6H8NcX/xqRLMt885U8TFoTsuUsKqigx9GDIc8QLi5fxGn/aTw58ORKWbPP6oNJZ0KmmMG1+DVAYdXO+eB5tFpa0WJpwbXotZUmgjqtDq2mVhh1RkxFpzDqG8VR31EEUgGEs2F8dN9HMeQeWomaNMq1adqda3cdpPzt3/5txOPxlZ85UZ2yE6Yo1PMYG1PTA6kUf5JJFbRoNAQqf/mX9Ai32oQ4nPBeAJ+67e0qd8Rk4hNPq+VrZjPBQrHI83zoIXrXRvoL+f3qkv3pp5nk/7mfY6nHkSN82nd2com+Z4+acjIYeNwnnmC/+yefpCednOSclsuqxng9BmS1l6hnwku0tKheqPb9asG7aoWzYpHX8upVsiW/+U3k/vFF5EPxDSMetf0Vt+KAhVaK379WiVRgtfZ2DlNQi86dIx2nUlHVZsWUvPwyM3Ji6p1O3o7T09TbczrVgFqhwHGHw7wNRJms6JqQTKq4Nhrl+4Lo+tJLvExWKy+34HYIYrDfzyxpNgv8X/8XXwuFCGhERVIj0aTaud1K+6vNrJG57+lZjZOB+l81YUL/b3i4vv5fRwdTSQ88wHmdmeFXbniYXyPRC/T8eYIuEXHKZnkNAI6pVOJ7p0/fGgVb0Uk5kU+spHJcsgsGrQEaSYOyUoZTJjdkzM+y/ycGnsADHSyACGfCKJfLyJaz0ECDLhvJq8VyER6TB6F0CEadEceHjmPYM4xYLoZX517Fs1eeRSKfQK6UQyqfours8gTeXHgTZr0Zezx7cMh7CN32buxt2YtB1yDShTSmolNQFAWpYgoH2w+uASlffuPLOBs4ixZzC/a27EWLuQVnA9df95+9+RPatBu22xpRaWlpgVarRVAoQl23YDAI7zpSjEajEcZ6cp87YeGw2ptGdPcVhFEh9RmL8enf38+nlGiNeitznvXE4axWPt1E2UJbG71PLqfWs4ZCJDK8970EDwsLjUUsJKm+SpeoPX31VbUGU5aZFhNyobVlvU8/vZr743avz4BsVK13dJRhg9rxFYvcTpSgzM+rKbBymdtkswQsOh3k2cswTpqRbd0La/fa5XO97FQjDlhQbxqpVhkdZfQim+UQx8d5+wnuRaGgapuUSmvpQrt28TSTSZUrrdPRmYsUR7nMz1QqdJQ9PcSakQg/J253sZ/2do758GG10EuQaUWn4EiEkZSjR6nf9/u/T2keAbgyGbUc2uutr1NSO7c72f5qu5VCN6rD6PNtzKOZmSFOnpvjPux2/k4meV+1tfEzxeLqlgs300Qn5TcW3oCiKLAarCuOX1EULKeXV6pmZuOziGQj8Nl8+MyRzyCSieAHUz+AU3ZC1sloMbfAa/PCqrfCn/Kjw9oBnUaHXCmHTnsnTlhP4J3QO3hr8S3IehmP9TyGxdQi1Wazeei0OixnluEyunCf9z4MugYxFZlCIB2AS3bBITswH5+HTtLBZXLBZ/Uhko3AbXJDUZQ1XBuAaSCHwYELSxfwrfFvreHaNO3Os9sKVAwGA0ZHR/Hiiy/iQx/6EAASuV588UV87nOfu/UDCgT4RHE41OS+JPFJr9GoUZZiUe28Nj29tlLlVlitKNm1axz/oUOqUxcymYI0qtcDP/MzTHr7fGq8e7O4ttPJXES9p3wkQk3wBx/kdrEYx3L+vMoqvXxZjXOfOUNAJbyry6XKmdZao15Cq63vhQoFjlFwckRJst+vir2Vyytz4B7ZjZ6ZACbGnBjqdELSqF5rvexUI+mcagcs9DxOn16rmSHEzCwWnobDwelsa1PVWUVkQ2StYjG12Angdnv3MlBktRK/hUIrWAyyzO2FTL1GoyrACkGydJqf0WqJx71etXCqpYX7Ev1tMhm123M6ze0sFuB/+9+Az3yGcyYaNIrWT0eOEE+KeVxvbne6/ZWY+0YrhYTdoP7fmgomYYpCIJpMqhla8aixWnmNwmGCF612dcuFm2mik/L48jjeCb2Dbmc3tBotsqUsltPLsBlteLjrYVj0FixlllZ643TYO/CZkc9gIbmAUqUEn80Hh9GBQrkAf8oPq8GKDlsHJElaJVP/duhtxPIx7GvdB7PeDLPBjEAygFguhmA6iEwxg3ZLOzptndBKWrRb2hHNRZEupJGv5BFMB+GUndDr9PjR7I9gXDCix9EDp+xcxbWpPcduRzcmwhOYik5t2jKgabfXbnvVz+c//3n84i/+Io4ePYoHHngAf/zHf4x0Or1SBXTLzWjkU2NuTq2UqZYVFbHydJqOuVy+NU+PeiZEyQQR4rXXuKRVFHqqUIjjlWXG8V0uAhXxRN5KfyGNZvOnvN+/tlxFsEonJtR9C9GIpSU+qZeWyBbs6ODYw2FVr6Wri17v7/+enk7os9R6iXpeSMh+Li3RU5ZKvG5CjSwa5TXcswdYWoKUTmFkxIzgyQAmz/fAN2TddNVdLX1fKwm/ngOuZ5EI8OKLdE6hEC9pOq1GVgoFFVd6PDxFESirTQe0tqrCwUYjwcbu3RxjPK4K8YpIhSRxmtra1FSKEIwTGNVm4+3l8fD/N96ggxW3hlC5FU0KBXn4G9/g1IsITizG8ubpaeB97+P5CHDT17f6PHay/ZWwzSIc69kN6P+taxcvsqKoUFB7fpZKBCYC3Ap9HKNxdcuFm22HfYfxq0d/FV/6yZcQyUUQzUah1+rR7+rHw10PY8A1gFQhBaPWuAp07G/bjw8OfxCvzLyCSqWCUDoEvVa/kv6J5CIY9gyvCLNFshFMx6Zh1plX9mMz2GB1W5EtZdGeacdYYAyBVADfvfxdlCtlQGJ6qs/RhzZzG1J5Vvj0Ofpg0pmQLWUxEZ5ALBdDLBdDv7O/7jnaDDbMJ+YRzzcQkmvabbXbDlQ+/vGPY2lpCb/7u7+LQCCAw4cP4/vf//4agu0tMa+XT+tr11SQUiqp1TKCvt/ezqWhUKm6VU+PehYMskRjbk4lC3R3c1yZDH+EqFk6zadsVxc/u9W49kZP+XqsUgHsnE52rTMagX/yT7jNpUt8OhcKPHY4zJTRhQskXoh0YFsbQwQDA9xnIsEn+ciIqmkuy7wW9caXz7NcZWpK7VSXSKjyq6I8JRgEikX4OiQcH5rEWO9BzMasm666t5pSqK4Q6uriECcnSbrUapmRO3SIQOKll9TOCD09atsmQTsSZb+10YZcjtMlelN6vaRXiTJkg4G8FuEI83lyWsxmFd/FYgQ8Ik1jMPBSZ7Oq3p6icOxCPqdS4WX0ernvb3+buNVi4Wd9Pt4KU1McVyqlViO1tTHlNT2tzvNOtb+qtfUiHJtZIzqMjZrfz1LtxUXeW+k0IzWxGCNVTqfKUxc/e/duDnh30o71HUOqkMJrc6+hxdwCq8EKr9ULjcRyZX/Kvwp0AOz/88TAEyiUC1hMLsJtcsNmsEGn0a2ka0Z8IyuppFwph4pSWWkMKDooS5KEslJGOBOGP+lHvpRHq7kVbdY2OAwOZItZnAucQ76SR7e9G/2u/hXxN6vBiiHXEE7On0SmmEEin6jbvydZSELWyXAYGwzJNe222W0HKgDwuc997vakemrN42ESeHFRJaNms3wyipisz0fnajLxqdnbe2ufHtVW7fU6OxkZmJ5Wm/u1tvJ10dVOo6HnEF4D2FpceyMBvFpWaSSiRnWSSXonq5UeMRDgk1l0bTOZWJN7/rzKGu3p4X5nZvie10t+y+HDvD7/8A+qHvuVK2ye8p3vsOa01gs99RSPLxq2xOP8TE8P9ytev369fW1lnDghISI1tupuNKVQi+WiUeK1N9/kZySJUZWRETp8s5lOPpkk3uzr4//5PHFnJkOiZj0J+fvu46mJPj5zc+r+AF4WEWAaGqJznJ9Xq8xF5EREXUwmvjY9zUze7CyPVSqpGoKDg8wC9vXxEr3+ulqdJOautZX7OXeOxxoeZqTCbK5f0n2jaZc7zUTA8Pnn+RUVui5HjvCa+v0q70g0idRqqaUyOnprqXCSJGG0YxShTAixXAx2o32FtOpP+deADmE+mw8ndp3AmH+MHJZcBEatEcOe4TVCa7JOhkt2IZ6LI5wNQ9bJkCQJyUISk5FJXIteQ6VSgc1gg0lnQqqQQrlchsVgQSAdQLKQhFFnxGtzr6HV0opB1+CKTsqBtgM4HzyPq9GrcBqdq9I/lUoFc/E5HPYexqBrCyG5pt0WuyOAyh1jksQlbSjE+HQ0ymVcIMAnud1O5ypJfPoKYsHtEA+qF8HYtYtOeHxcLTNRFD75PR4+DSORtYIV1XFtodzq89F7iFLizRTNBKtUaL2PjakCHno9PWU8zlIVj4deTRzfbif4W1xkKEHUogoPCNCLBQIc0/g4vW8wyJ/XX6c3f+IJ5hqefnr1XO3bR8935gw97vPP08ufOcNUWTRKwGO1cg6GhyF53PBs4bI2klKoxnLRKLkb8/OcWtGj50c/YulvSwsDd52dajO9CxcIHsxm1eEL+k11FMfpJFhQFN4alQqn12ZTdUGsVr4uwEYup6ZeOjsZqFpcVC+/CECNjxNclcs8vsHAsQktQa1WreCJRFbr7wkTXIxUiscSYGg9TZWbkXa5FVaL6/N53nJC0M9m43vxOM/n2DGCsZkZVXpoYICA7Mknb4+CrWg6KECHUHetBzpqP3fCemJToTW3yY1eZy9CmRCypSz8KT+cshOLiUVEshHE83FYDBYMuYdQqpSQLqQRzoURyoRg0plg0VtWqpEWEguI5WIY9Y2uyOvvbd2LufgcLixdWKWwOxefg8fswYf3fLhJpL0LrAlUas3no2BBayv72cfj6upeCFm0tAAf+AAd4+3Sv65XF+t2M6oyNaWWRFgsBFtC0MJorC9VLxh8Yrmcy9GDtbUxaiS8xHqKZqIq6ic/YdQkHKZnK5fpWfR6tSlNLes0HifQECUioplNNsv3Wlv5lJ+d5dN7aYneWeQffvZnmTuJx1mB9fzzjKwIkyQuR8fHgf/n/+F2djs9g1BQE4zR9co/GminsFlKoRrLicxXIqESUkslTpfoMaPT8TWDgRGSYJCXae9e/nR1cfjVUZzWVh7rRz/i8UQ3BZ2OK/hcTk0VCen9bJbbvfwyxyG6GAtetNXKSyOIu6KwrFRS+ckWCxAMKnjx+wWYizl4bRoYjVYAa9FeNssx1cuYrqepspNpl1thtbhe4GyXi9fIbucc+v28DwCCtiNHCBjHx4mhf/EXb70yba01CjpqTZIkeMwb59gkScKIbwTBNFO9poIJwXQQ0/FpFMoFmPVmuEwutJp5Y+dLeUgJ9vzpdfRiJj6DfDkPvUYPl9UFf8qPqegUXLIL2VIWg65B/PSun8ZL0y9hIjyB+cQ8ZJ2Mw97DTR2Vu8iaQKWe+XzAz/88ndvp0/QCWi09SHs7X7/dMvrr1cVaLIz2WCyMDI2MEGiIsdaTqgdWp5FkWRVue/VVehWfj+BM5CKKRYKYYJBP5MOH+SSemOB7AkCFw1weChE6i0WtVRURm3CYXlbonIjSYeG1Rb4jHudnRS6ktZVjs1qp4/4//ge3OXEC+Md/VMGZqOX90z9Va3Z//ue5T0WhN0yneT5Hj67uQyTmpl6ZzhZb24oKIVGJIyhQYkpE9wNR1SN06jIZYr3776fz/tCH1CDaoUMqfopGmf0KBomt+/p4vJdfVrFnby8vhRB8S6c5nZ2dvDX6+3mqP/whnWo4zCxZLqdWdd93H7f1+/m/1QroKnk4pCyuXtIgYb2I4w/N4J3sgwhNt6Fvn2XVV0U0825trV/Ns94terdYrVKxLBO/T09zrSNkfzSa1UTgdFpN++zbR+mh6gbnt9MaAR3bteqozUxsBpCA5cwyehw9CGfCiOQiKFaKMGgNkCQJFVRWiLeyTkapUoJG0kCSJLhMLiyll5DIJxDKhDDsGcaxvmN4rPexTbtAN+3OtSZQWc8kiU+J6sYfd1JjwvXqYgXXolzmkq12vPUEK6rTSG43/06n1davP/kJQUu19KnoQGyzqcIaDgedvGgUI2pt/X6+19pK3oqobRXKVnY7xxAIqCJ1gMoizGZVNTBRCmM0qqIiWi3H8eEPkzi7vMz0z7/7dwRQ7e3Axz/OmPrAAAkPHg/3EQjwfINBVd61mtHp9wN/9Vdq6YqwiQlGnz75yYbBiqgQEhUzmQynM5dTqz6EhonouxOLcUozGbXLsBBRA9QozpkzwJe+RCxlMBBsdHaScnXiBIumLlzg6djtqlqsEIAbGOAx2tr4mb/9W77X3682wA6FOF06HS+TqHDPxvPIx5LQlkrQ6qzo7DfA2S7jgDyJV2YVLOrb4e62wGjkZRQRhIGB1fyajW7RO8Ea6VFaLyObSHCehob4eijEr8LCAuews5PvHzrE856fZ2Rl377bcZa3x6qjNv6kH89OPosOWwcmlidwauEUkoUk3LIbZaWMUqUEnaRDrpyDw+iAXbYjlo9BI2mg1+qRKqRwJXIFfc6+FQ6NJEnNEuS72JpAZTPbbonAzbb16mJtNi7Zzp/nk69aLWu9etlwmI7YZKI3S6VUBmQySbAhSkjsdi6pRdJ9aYmkgkSCRAIRZRGAQqtV+R8PPMDXrl1Tuys7nVxW+v0ECAaD6qFMJgKc8XGCkrY2jkW0pRXNWUoljtPvZ6Tj8mUCoC9/mWmhb3yD4xwYYHihu5v79/uJGqpLcJaW+NrUFPCRjzC0UF26IrxtJMLXW1up0tsAeK1uWPfmm5wikVYRYmwGA/+WJAIHr5dDE4Gkeg787FmClAsXuL3drk7z8jKFhI8fVylDmQyd5ewsAUihQOdotar9I3t6CEaOHmXUw2bjmF9+mbdcS4vgoyho1cdgsCWxVHEiGQeuLtvwzbNDyFkk2DRJZIIGRCxmiDSQycR5qNccfSsl3ZtabUfwGyC2NNpRu15GtljkjyxzLpeW1NSawPDVqsBdXbeeOHsnmIjauE1uzMRnMBGewIBrAAvJBVyOXEYoHYKsl5Er5aCX2JV5T8se3Nd+HyKZCEKZEFLpFIqVIva07MHjfY83OyTfI9YEKnerbVQXq9EQXGk0a5mW1RwMAT6ef56CDlYrSa8iiW6z0RsZDIyoWK3qg16jUcuzQyF6ugceIAg4epQOQsiiGo3cxmIhyLFYCC4KBTqRsTEuU0XKZWZG9WKFAs/BYKD3CgS4L0BtghgMqvyX3l5Gwp57jtv96Z9yW6+X9b4CpKxXglNdMj03x33Ulq6YTPx/epql1MeP81w3MLEar1SA97+fzuzFF1WJeyGdL/T5rFYVwxkMHFIkwktX7cBFP5zlZe5D6I1YrZzmmRmScz/2MZ66xcLjiO68Xi8vxfy8KiAXCqkV+Farqlobi/F/kdLQ6YBUrIxCUoHdasZsyIx2Zx4He5OwmsvI5rXIpfWIRJbhcLugtVpWsmZdXZz+NSXdiwpchjRGfElIEcP2I5gbtVzeYqnQVjpqZ7MqBhcFbCLIKQBOLMbrMDrKAOPcnMpV2rdvY/G5d4NV81YiuQhGfaOwGWy4uHQRC4kFKFBgMVpwf8f9OOw7DLfJjX5nPxL5BK5ErmBPyx58fP/Hm6mde8iaQOVutvXqYh94gA/kWqZlrTjbCy/QoS8v8+kp6l7jcQKNwUF6JiFX2tmpqlIB9L6xGPMDy8t08j4fPyfkT10uOopKhd5QeN/JSbXvkCxzab97NwHW+DjHDXD7I0cIBBRFbRecz6tREL+fT3mhaTMwAHz+88Bv/ZY6V//8n6u1uYAaRTKb6SlEpZTNRs9sMjGfsrRE1d16pSttbWr35g2ASr3V+MGDatGSUGkVGiZGI8FLby+nb26Op9XZuZrnqyis3D57lthS9IgUzQUlicNaWCBg6e8ntgqFuK9cjo61UCAwsVrVy2Iyqa2YhAR/JsO00EsvcZ/t7YBsKCOS0eNq1AyrXMbPPBSAw0qOkdVUxshwEZcv5GFvzePI+y0rl1/0yFx162ZjGM5dxojpEnw/iq4fttjMdqrlMjZuOjk4yMDlc8+xg3ShQLx/4QJBjNXK6zIwoKZ6nE4VuAhCrU7H03zmGbXj9LvdaquNep296LR1wmwwo93cjsXU4gpvpVwpI1vKIpQJoc/Zh8f7Hm+ClHvMmkDlbreN6mKrmZbVr/v9wPe+x6W2ovChPTFBLybqWHM5OuDBQXpNs5meymCglxH8EquVXvfUKdV76XR8Oi8sqCmZzk4eZ3pazTOk0xyP280oSDRKb/qJT6iCb4pCQNXXp7YvuO8+jj0c5jhSKTo10ePI4WAupNr+8i/JU/F4OJ7nnmPqxm6nF49EVC8iOC8ilBEKqTr2W7T1VuN+P6dWllUNFUANUok0kMi2HTu2ushMgJ8f/5ggwucjCEqnV6cdTCZiyNlZ4i2A0yP6PIo0j9fLyxYOq1L4JhN9e7msEnS7ulRSbzAIlPJaKCUdLPoSPvRAACODyVXnH40qCOZseOt1M5ZKPDfRUWHVrTsThPzqC3AbgpA6fICpb/2wxUa2ky2XsX7TSSETNDfHTOGZMxxuezvnaWmJX5mFBV77wUHO9eQk1wtmM2/bxUXedgcO8P1cTr0H3u2AZaNqI3/Sv+WS6abdvdYEKveCrcejqfe6WCIuLqoa6WJJl8+zxGNxUY2SiLyEXs//DQbGqYW8qchNDAxwOf+d76wmnRYKjIh87GM89l//NX97vRxbPs8n9JkzLK2em+Oy/cABfl40OszlVOalx8PUi0jPxON8uvf2cr9f+hJBltcL/Nt/C/zH/0iw8bM/C/zN33AZvLDA/QmVrXye++7q4nwIRTTRknhgYHVERlFUALNOA82NVuNCL0TgQNFZN5Gg/2xt5eFEIVJ1kVk1+GlrU6V9AH4eULNuiQQvgddLBxkMcpozGf7/zjucAkGQjceJIwsFvu/x8LKHw9yvEAUWXJtEXIvyeABvX5BwX39q1flHkjqcvqBF0tgCvcUIr5cOuhZ7eNwKcOotoBQEdq0zUbXaP+vZVlouN1DvXK+4LhIhWXlpieBEzE8ySTx9//1q1ZbTye3n5wk+RIPJmRl+Npcj9v7KV7gPk4m32oMPbrmo7J609aqNtlsy3bS705pA5d1mYokonpaiYYzNxge30EWfn6f32rePHuvMGT5l3/teNR0kiLqTk3TwgjsCcD+i/Fer5RP7hRfoOffvVyt7TCY1fbO4SM9YXZe6HmnY4+FYzp9XmZ+XLq0GKf/hP9Bj//IvA//1vzKa88EPAp/9LL1/sUh2aLGo1gGLMhvhuU0mztfCAp1cNZm2WNywne16q3FA1QuJxYjhJGl1o2uht1K7sq4FP4rCYU1OEqcJEz2CgkFivp//ebVQTGA+oV9YLSC8vMz9ORw8vXye4MJm475EsEyrZaYOkOC3tWNyOoxyYJkHMBqh5POYuqhHGh64h1zISBJkeR3sUWeiFAWIJPXIFbWQrb1wz8xyu82I7TvZchlri+tEGy2hgSP0EXU6zlswSNLxT/0U8bfAu3NzbLN17Bj3NzPDyv9cTu1+IQrhZmaIo7ZYVPaus5tZMt20O8uaQOXdZmKJ6HarDD+xXLTZmJ4RNbBCW0Sj4RNWEE2NRm6TTqtSqACdzAc/yCevULnVaJg/+M//mZEXj0dtQSBMyJ4uLqotc6vf26iZTlcX9V0WFoBf/3WOsa0N+D//T243OUnP+p3vEBFMTwN/8ReMGLW1MfojSep5JRJq6qezU21PILrgabUqieShh5iPWWcVt57UjTChF5LP8xCNWK1PlySuvkMhOjinU5WGEdUlv/Eb3L+irMV8bjenPpGgrL3BQLJvLMZLGA6raSjBqRBiwQD3mdQ4MfxeCclYHt7UNKRYDMmyGUu6Xjj3tyBWtK6S418j6lYzUf6IEWNXHZgNmZAvamDUtqJH0WLkoQJ8m/mlHW65XIuTk0nOtajYyeVUiSVF4fbhMLHQe9/L9I7Ior73vWrfzVOn1Cbs165xjs1mDise57U7eZJD/Sf/pJkOatq725pA5d1mYomo09FRi+Yp4glYKDDv0NHBCMt736s+JYXmSC1Bt6+P+iMiRHD5MkGM0CoRZc+SxGiF38/PVIfmDQY+4dvb19albtZMp1Qi/2Rpifv/3OdUkblqAvFf/zX3EwoBv/M7wP/+v6uqw8vLqjaLw0EgYzbTi/T20hvNzxOwtLcDjz1GXXOvl+OuI66xntSNsO3ohdQDPwMDxIevv04sFY1yuAcO0MkJ3uhGmC8U4v+KQl5xOMypAAgwBgeJI+fm1KoVgRXdbuCnfsqBsTE7Jhd64HMXkCsZkHrLglxegt2u9pQUtkrUrWqi/AUPnj3dilhaD58rD5OxjGy8iAl/K4Kv2vDgdSrSupJGO9xyuXbORJGZoHMJeaBAQOWj6/Vq2wO7nUMQLa0AFWxarQwIxuP8TDK5ukQ9m6UskAgkbYdX3LSm3QvWBCrvNqteIvb306uJsmWDgU9cWWak4vHHVz8V1yPuLi6quYrx8bWMTo1Glb6PRnmcUIjOQvBUAgE+1dcTkFjv2LkciZFXr9IbvvQSvWg9Va6BAXJWvvxlHu9LX6KH379f1Zp3OjkvOh3nSAjZHTmi6rVEIvxbqPKuI66xXtYK2L5eyHrgZ2CA2G9sjLyTgQFiKCGmKxzcRpjPYlFbNAmtP41GVUsVUZlMhtNVW0jW3i5hbMyK2VkgnFQFivfvX3uOq0Da9YlSxicwFu9HLK3HkC/D+VIUWLNLcPf04dVzFpy+PpeyvI7jvgktl6vn7MIFYtd4nLtuayMAyWTUEmOjkfMkitpqr7MAm4mEmn01GNSWCfH46gykzcbbcqu84qY17V6xJlB5t1n1EjESIbNycZE/4XD9EpPaz9fyBGq14avZnckkn7CFAsFPPM6IhN+vOhKxRD52bGM5znrHNpmA3/xN4A/+gHKqgvtSrXsizO3mavqXfxn4b/8N+Kf/lPubn+c8XLqkdsvTavm7vx94z3tWV490d5NNee4cvWVHR11xDcnn2zBrtVFboXCYWApQecciVbMe+IlGiROdTp5mvY7EXi+d4qFD5JgItVuXC/if/3M190KnI0Zrb1cbYP/Mz5CWU49DU40ls1lWJC0urs3ArHHe1+/JyFQMs++k4POVISlaIEeidURyYywxhFxeQuV6Wkuv38Bx34SWyz4fser8PG8FSeI5xmJq5jKXU1sTaDS85Scn115nWeY1uHqVwEScD6C2KRAKAEJnZzu84qY17V6xJlB5N1rtslq04a1XYrKeVeuJG4103m++qarGim1E33qRSpmf59PWZlPJq11dBApHjjAcAKz2zpvZT/80t33ttY1lQ6tB2r/5N9xGdIubnmZI4sABNc0jhEPqrb4zGW5z//1qaKOON/H5pA2zVrVYUMjbnDqlVmgLWXuBHeuBn0yG5ExJIq6q15H4hRdUXZbaabp0ibp/orCpVOJpLy+rVehmMyM1QjJmPUl5gSUff5zVSQ2BNJ8P2UefQOTNKAyxRVRiOdisADo7MZUaRjpuRU8PcXCl0oDj3uGWy34/8P3vE3iJLtOxGEFFLsdzFnOQSnH+SqX611nwgpaWOKxMhkBFkvj1Sae5Xkgm1W2B9Rs2Nq1p97o1gcq71TbSX9nM6imYVeuvyzKfvEJswu2m55ydpbdqb1cbDgqxNIcD+LM/W987bzSWRmVDFYVL2cOHoYxPIDKXQS5Tgdy2F+52LySTTC+o1xM4yTKjJdVWLpNYcOEC/xdlzcLqeJNGp1q0FXr9dQ5B0GdCITbyXlpSq0BqwY/AhyMjax2YJPGYzz3HKMrQkApuxsbUDgWiICuT4WWJx9UuCi4X/bzgTYtbQEjQaLV04MeOqVO2GbWo+rL6/cCPL7fj7WIbxiu9sMpltFkltLaZsbQkweXiGIWqbjjMOfJ6N3DcO9RyubrSatcuVWR5fJxzJhSHe3o4XzodC8sOHap/nSWJcyC0BUMhteI/k+E2guc+MLC6gOlub9jYtKZtx5pA5d1s2+ljtJGCmdlMZuGZM3xyF4tqw5pgkCBmaIgeTwhIzM+rEY2eno29c601IlQilttVRGB/SIuxYAdmc4PIu3wwel3o2WvGSH8MPmeWXl1RqLlSTQY5c4a69zMzPBchPPL008CRI2pJbc4FORKHO5uD8FGbTbWiMJsk+jmKzJWiELMtLHD4u3YxgFQLfqJRRkRqcZXY9+IinWFXF08nEmGwIRSidI6Qx49EeAmtVrXEWRA7LRa1kvzZZzkN1dyMt94iyPrUp9TsSiMgTewvGgW6uyUsL5tgdgPzUWDu+udcLnJDJIkZN9ETU6RN6jnuRpoINmLVlVYWC+enUCCOnp3lLZrPE3To9QRr73vfxsfq7eUcud28rQR5Wa8nmBO880OHNu8pupO2U3PWtKbtpDWBStMat82AwdgY491CxdXpVDXbhUCH16vWYmYyfPIKj9jeruYe+vroXS9epAd/5pm1T8zNhEra25mOSqUY2dHr4TcP4tnlXsQSgA9+mPIJZC2jmLisQTDkZgDGg7W1vGfPsgQjleISt1jk0nluDvj61+FPWjFmfpQltakijEUTen5sxcjjjREfIxGmXyoV1Tkkk2pkI5fjz7e+xVX2/v2rwY8sq12Xq0m2AqRcuaI2tBaCZaEQnaPoLZlI8Pcjj3DMZjP3US4TTwpxOQFSIhFeQpeLQbFcjtjwa18DvvAFFTRtBNJqoxUtLRybEEvz+zmmXI7jE0J4Qs5mepr7F1XkwhptItiIVVdaSdLqDhGDg9zvwgLnZ+/eDSvWV8ztpsCyXs9M6+QksXylQtCSSLDsXLSmEnO1Yw0b69jiIvDKKwSE6TTnub9/dZSsaU27HdYEKk1r3DYCBgC9VjRKtStBrBWlDFotl5zCiyoKvXCxSO+pKKsVbQVzNBLhUr2vj8etXuIJDyLLfLKLZbbNxqftyZMEGtfVcpXhPRiz70KsbMBQXwYSWgC/H9bAJIZGj2JySqriO1TxWSYmSFBIJvnEzuX4FNfrAYcD/pkCnv12HrFHzfC58zDlFpD1dmNi0Y7gs41VaeRydA4Anaogr+ZyaoPBpSU6xB/8gNNQy3uoJdmKzNvVq6T+dHWpRVlC4E308jEa6WgXF4Gf/ITV17UFWUeP8vKKSEoms7oZX7lMsDA/T4f3iU9s7rBrbym3m4VfU1M8X62Wc1AqEXcODq4lpWo0vNyCWrWVbGAjVltpVTtGMYcjI2sL5daz6tsrFmN7LlFUNjNDXG+3b9xTdCft7FkCzCtXVDVjo5FjOHUK+PSnt8VBblrTdsSaQOXdZhuVlGxmGymYJZNc+pvN9KpOJ5e/wjuOj/P9dJreR3BZrFb1b1GxI6xQYMRC8FZEIxWxLBbS+idP8vgCqJTLal2uyURvZjAgcnkZs5lr8D1ggCR5AEgrrEYplYTPZ1/NdxAki69/nd7XbKY3sdtXWg0r6QzGdI8gFq5gKP8OpJgM2K2wHujDkEtquEpDltVgkhAIEykPoUen13NI6fTafdbqfcgypyAa5SVraSHGunqVYESS+J5Gw/dFxKK3l8eenOSp6nSrC7IWFzk/iQTHlkqpUZ9yWR3ruXPU4dsss1jvlhIE0mSS7587pwolC+626LxgszHCMDfHcbndjWcDG3X29UBgtVDelSukNH3841vj6tZyeETk59gxAr6NeorupC0ushXWuXM8H/EVFV/XdJrv/+ZvNiMrTbs91gQq7yZrpKRkI9tIwUzwUQAu39NpFTi0tBAQzcyoy8LOTjr7t95SpfOrvVUySeG4eJw5gYGBtTWpIipz7ZoqrpHNUktF5AKE1orTiZzBhfz5CkzTF4HuR+lVjEZuWyzC5KxDVPT5yEA1mxkHF62Jr+doIlENZsud8JVmIcXdwNBRLvvdbkhovErD7WbaYGJCLZSyWlWeihAD6+nh7uvtUzi+06cZUZif52v9/cSLiQS3P3+ef9tsBEfFIo+fyahN8pxOnrZQzRXpDIEnhV7ItWtq1Ec02Y7HeR4zM5sDlXq3lDjfYpHgx+vlraHXE2PHYvy7o4PvGY28DbLZxtoWbLVqZjOhvL4+RlK2U1C0nZ6iO2mKwujX5cu8J0TDc72eQDUS4XZXrjQeJWta03bamkDl3WJbKSlZzzYS8RCtdysV/m0286dcVstDe3uZdN+1i9GWbFYFCwIAACoAiUTUslKnk8cTy+LTp7mtw8ExxWJ8wgrei6JwaS88UzoNuayH0aJDNhiBNRpVcxt6PaDXr09UFMSITIZP8kyG56nRIKfpRl5nhskpAw8+xPh41bw0WqUhSUwnXL5MnLW0REdcqajRiuFhToXZzMtWb58+H5X9L11iBMTpJCCJRjlly8ucllSKp59KqdEaSaKzEqChXFYbEIrbwu2mYxbUn+qoT/WUSxJvkyNHNnZstbdUNKqmVAoFtfOw08njCiG1VIpzcOGCKkL84x9zjhppW7DVqpmtVDBt1dbj8GyH675Vi0QINpNJ3taiswbA3243r0k8zu2aZdFNux3WBCrvBluvpARojLQqbKOlZSCgVsGk0/y/XFb75sRiZA8+9hiX+kKS8/HHCV4uXSIzsq2N+7t6lSCmt3c1MUEsiy9d4v979tCjCe8mGrC0t6ts0FQKWFqC2yijJ+/CRLITQ5EoJPEU7uyEYrXBP7UOUXF0lN709dcZHbJYVhq8yPEwjNEgsrt6YD14cM3cbaVKw+cjVpRl4BvfUJsAOp08TVHumkptvE+BvTo71Wya4FW8/TYvc6WiOnghMKYoKtjQaHipHnlk9SlJElMTL79MLkt392rwIEi93d2c2s0cW/Utdfq02pzPYuEYW1p4iwUC3N++fby9JiboWJ1OXm6vl7exIN7uZNuC6uuz3Yr+O9UENyqX4zXX1XgErZY/+by6XdOadqutCVTeDVavpERYNWn10qUNuwEDWH9p2dlJZ37+PEGIcOiiHayI8T/8MI9Z/aQPBNSU1OwsP6PXk705MrIWOYiGiOJvq1UlNczPc0wiujI1xeOZzZDKZYwY3kFQMWFyvBO+wixMnW5kvUPwT0nrExU1Gnr5s2fVRjrX+THuxDJ65F2YaH0/hiQNqj+6nSoNnw/4lV+hAz5zhlMqZGhE1GKzfa6XoXO7WS00Ps7/02neEkK+vVgkthOaKlNTBCq11tFBUd9Ll1QVWqORYxSk3D17uI9GHJvPxwrvP/9zBuVcLoKnnh6mrVIp8ifCYY49l+M8DA0R/9rt1OlzuZiiyGYJWnbt2pm2BdV2K6Ict9IEN0oQuEul1U0nhdyR0aiWpzetabfamkDl3WC1JSW1Jl5rdMlUb2mZyQA//CGXtgC9SjJJLyikPMVyt6tr7f5+7ucIgMTS+eRJrGq5W23Z61onCwvcrrWVXstup4ccGFC9sc3GMeVyQCQCX/wajvv0GDPZMZs/jGDLURglx8YhfBEW+MQnGEaYn+drOh2kwQGMHBxCMKbD5Pk0fEPWG67S0Giow5HLqQ2oK5XG97lRhk7odBw6xABRLkeQUqmoTshiIdh4/XVeZqFEW21Hj/JyLS5yjIpCUNTezuk3GNSCrHWtSrTDmDGhvc2FzqckGAwcZ7FI3HvmDEEPwMspeBMTE7zcojUTQBAlUllbaVvwbjW3m/MnKowikbUcFauV7/f335yy6KY1bTNrApV3g1WXlNRL4At11a0smWqXlpEIgYngctRuazbz/Wx2/f21tPBHUeiZJiZURqkwRSGJY3ycXjKV4jEF4/PIEdZ6ipKXlhZ64XKZHqy3F773P4oT3nZE4iHkTlQg+zYJ4YvSlAcf5M/UFMdntwODg/ABOH5uEmO9BzEbs+4If+FGOBEbZeiCQaZlRCVQSwunRVHUlXRPD8HG3JwqHFxrbjcV6g0GghOxEhe4cnJyk8hFjdBJLutG4eooOh72Qetxr2i9TExwbH19qgKuJBGQRCLMFgrOdmsrtzOZgEcfJd9nepqX3+XafO7ejWJnIpX3+uvqWiYWW8lswmrlNd29m9vd6/PRtDvTmkDl3WDVJSWRyGqOing6azTcptazNPr0Npm4j8uXuZ3Npi6Ll5f5+Z6e9VmO1Vbtac+dU3MfOh3JES+9xGN1dqpiIEJmNZulx3r/+1lRlM0SVOj1DC88+CAwMACpXIYnOw24MoDHtfF4anMpu3evfj+Vgq+tjBMnJESknXN0N8KJWA/o7NlDmZt/+Adems5ONfqRzaor582OUX2JQiEVDKXTDUQuqqVobTbAZoNcUWCM+JE9FYLlkUO4es29clu6XKrEBMmQxgAAcIhJREFUTqXC4wUCPF4ySeBlsTDAJoDV5cvcvaBJuVzEsOuBlJ0UiLvbrKODasKKUl9HZdcuvt8sTW7a7bImUHk3WHVJyeuvq6RVgE/9YpGlIqOja7XNG316C/Ut0fYV4JNPWLnM97eS5Nbr6XnOneP/Hg/ZoBoNl/MaDat+olGClcVF6sj/7u8CTz3FsEA+z3MymThmUUO6FVZlnVzKilx+QQN5fg7uI72QPG54NnLwN2nJvt5uNwI6Oh1vBdEYT6fj9l4vsZi4RUQmr55tK+ojiN2XLqlkGK0Wbp0ePfpHMDHdijbbNEIZF6xWaUX0TVQ5VVeUt7YSGF29So6K18tqpECA59nZSecq0j7f/359sbedFoi7G+3wYaoJN5Vpm3YnWhOovFtMlJS0tqqkVWB9HZXtPL3NZnoHUf0jlrOi6aCowgG4NF6vs231sR95hNtEowRaon2t2NZkogcuFLj8i8eZi9i3j952YmJ11RDQMKtSBQAS5L5RuANBSJOT8Mv9GFv0YnZRi3w4DaP9MHr6hjESkNZ3aNtYsq/3kSNH+LfgsFy7Vr8jsigTrkf+3L+flJu//Vt+RlyiQoFTXCxuzqsGthH1uXiRPZSmpngQm42aMx4PRqQzCOYP4spZC1KeHNw+E/J5RkryeTpOq1XFxKmUqt0yO8vxazTEygJwARuLvW2lXdS9nvbo6OA98W5LfzXtzrcmUHk3WS1pFaivTLudp3c+T4Cg0ZCj4vGoiW7R0a6lhdudPcumNRMT6hNxeBj48IfJ8hTHdrsJTkTURzSkSac5xuqSZaORxwyH+bMRUWOT3ISi0J++9ZbaBUCWveix/gw69e9g7GQJsUQBPk8epvtcyHYMYWLJVVcuX1GAyMUAct9/BXImAvegC5J5c9C3Hk584w0GjbxeTuXkpNo1ua+v8UiAJBGbLi3xXEXLJYCX8KGHGutZI/bVUCWMCGtMTHDQPh9RRTQKZLPwDQ7ieOUsXg4VcDY+irmQmjXUatXsW7HI/9NpFZgkEsD99xOHA6sDe2KM9cTetioQd6/zWO61qqam3RvWBCrvNqsmra5n25H3lGVGZ1pbCYJES1m9ntU7Xi8/e+UK8D/+B8FEdzdX1MkkwcvcHPALv8B9yzIBSzpNUCG8lCRxiS1CANUmBEbEuYm611deaZhVKcR7n3tOVXLt6ODPeMiD52ffC6cvg5H35yAZyB61ShKGlLX4ze8Hxk4rmP3HEPLTLhhbetATz2PkQAE+j3Zd0LceTiwU1Euj169ukTQ+TizodjceCRBBNpGJEeH+vXuZBdzRdIc4qeVlDt5qJcowGHhNolEgEICvtQWPZcbwsuVjyEbMOHqURVbT07weonGiaCfQ1sZdLy+r/YZER+Vaqyf2tlFXiNrPvJt5LE1r2u20JlBp2lrbytNbWDWPY3RUVRMTTmlqiqy8l14iSDlwQE3fuFwEHRcukOXZ2UnHlU6vBku9vQQ8s7Pch92uvlepEMAcOsTjA/QsZ86ssCoVjRYRXTty3lHIBi/cymonLqIYP/kJnd/+/QQHfj8d5O7dwNy8BMOgBfBYUC2aUovfCoXrEZFLAfgm34SpnEZ2XsbElAvBCS2OP1GCb8BUF/TVw4mKwinMZAhElpf5utdLTOf3832hEtuoVLzPR42/hx9uLEqw7YiCOKnOTqYARS5HkvhjtbJ3kqTB2eJD8Pk0MLTyfLu7CdqEZH2lwnPq6lJ1X7RaRlECAfIq1qtqr6UlbdQVovozsRg5PVX8X5TLBIjvFh5L05p2u6wJVJq21hp9elc/8atTLVNTfGo7ndxWeFC3m0Cmu3ttYxSNhq9PTzPXsry81gtqtVzuLy/T6YkQQipFkOJ2s82rVrsmd+KX+zE2bsLs6RLyP5yG8ZCMnoPOldVwpcKCokuXVI6DVqtSYAQQMJlIg0kmiZOqTeC3bJb839hMHEPLpyAl/IDXC6vRiKFCEpOLZoy9EMOJj5ggOR1rQF89nJhMMpIggktic6ORU3S9t+LKuLYiFd9ouP+GIgripNxupgiDQXp9q5XXW1GAaBQRWx9mjbsxvFdCwUiibDDI8S0tMYIiywyaiZRQMkmcK7gr9YDTerSkjTRnxGd27yYPaGaG98nk5Oo2VonEu4fH0rSm3Q5rApWmrbVGnt71iKiblYEsLNC71FvuAny9UuEyORxeW3KiKPRI732v2r0vEKCHOnSIIOXJJ9fkTvxRGc+ebUUsrYevLwc5vIClBRPeyDowNSXhve/lyvjb36YD8vu5ku/oUBVhXS4OSTTkKxbXDl/gt2wWmJ1R4MtMQSpcd84aDSBJkIwG+DokzIYsiFyYh2dEvwb01cOJxSJ/ROdgsbkANFW9FVeNZaeURG+4MkaclE5HMk2xyOskSNfXwyS5li7kS90wtdpg1amCw3v2sKLnyhUeW0j0BwLcpdXKW9bnIw5qlJa0EZVpcZHAx2KhlmEgoGYPxXVYXOQ9cf48eT1NfkfTmrbz1gQqTVtrN0BE3bAMRDSDSSa5j1pLJvn+Aw8wfDE7q7bHzeW4rE2l1P5BBgP/7uoCPvAB5mqAVbkTBRLGrjoQS+sx5MsgmtJjPDGA0JSEYm8Ob5024cUX1ebM7e30nUKSZXBQlYYXhM6lpbU9Uarxm8kE5CNpmBJBzke5rGrDSxJM+hKCRjtywTjPs6ZNQD2ceL1v4kqlT3c3t11Y4JRV9VbcEan42nO74cqY6pMaGODORGdEjYYowG6HvLcfxnQnsjlpRevPbuePTsfrkkrxfNvaeH06O0mNkiReu8ceY2Cu0ZLpevg6m+Vcm0ykOL34Io+/a5fK4xbRtoUFRn7W0zJsWtOadmPWBCpNq283Ko1ab2k5OMjPnz2r1pIKq1RIpj18mBoo4TA9hNBHCQTopUql1Wq0ySTwzjvc5s03GVVpbV0JNUSSesyGTPC58oim9Dg95UA6q4FLtwSDq4hAzISrV3lqlQoX+qJ4SPRatFpVIGC1cttgUE0N1eI3gwEwaovIZhRYW4wEW+n0Sqojq1hg1BQhL88DR0bWgL56ONFs5rEvX1b7NAL094uL5Gn09fGzk5M7KxW/HW71Gqs+qUiEIZLFRf4IvtHjj8P9U+9Hzxln3WBeVxfBic1GLOt2qzQlRVHVcPft489WuDTV+HpmBnj1VV7Hjg61a3ChwKG2tRHQer0ci8Wiknmb1rSm7bw1gUrT1redbher0bAEeW6OxNnqqp+5OXq5D3+YCOCJJ4gaxsfVHvTlMgkB+Tz/X1oiD0YwKU+eJCD49V9fyZ3kihbkixrIhjLG561I53TwWROQ8hIyZd1KpfPUFH8vLKircyGq6/XytyyTIiOyWOvhN0UBevo0mHjLgaFcHpLVSlDl90NJJOBPmjHsmIO730FQVgf01eJEQe/o6yMIMRgIkvbs4TYi6hKPb0+6fyOS7Ha41XWt9qQ8HgLW9nYSoPftgyRJGJHWBvMWF/mxfJ63wSuvEKzt2cP36wX6tpqGEf05T53i7bRrF7Hl5KTaYqBS4e2o0fBWGxjgb8ELalrTmrbz1gQqd6vdKkGH7QgrbDS2w4eBX/s1VUdlfp7bHD5MkHL4MLcTpcUzM/RaS0vcr1areolKhR6lpYWowmJhlc+PfsQ0w+XLkNucMOorWIobEIob4LLkIaVTgMeNeMEEv5+77ehQ+R2BACMYFgsPe+kSV9HHjqm6eIcOrX+KkgSMHLMj+LoVkxcC8JmDMMX9yGYl+HNuuDxljOxKQTpxnEv/daweTszneYrVIOlDH2Kli9PZ+K1QfYk2E43bDrd6SydVM+BaPHP5MoNmWi07ILjdxK8iO3j4MHDffTtTJlwdPQJ4jFiMwFBwgBIJVS4onyd4HBhoApWmNe1mWROo3I3WSPnF7VKmamRshw9TAn89ZVphRiMRQlcXY+42Gz9TrQAmPEexyP3n86wjfewxIBSCO3gJPTYT3phuRzFbhrEQBswyFK8P4RkJ2Sw/ZrdzNz09zCzNznK6RK/Dxx8npqgGIxuW/XZIOP6MFmNjZzA7ISGoNcOoL2NYdwEj4QvwRexA1wc3vSb1juPzbe/SiltiZoYYMRolENtMNM7r3R63eksnVWMCz7zzDvDVrxIUtLeTC5JMko506BDJtb29HGft7bMdq44eJZPkuqRS5KeIaup4nBE2o5HbOZ0ESs3Owk1r2s2xJlC526yR8gtABQu5HKMObW3A0aOrve3tGJsAKxoNY+sbmVjuKwq9QDzOc1EULnE1GkZVFEWVJ3U46I0B4PhxSGNjGCnOYOqKggvxHsid7XD0tyBWtK2UvYqW9lotP+718nDT0xzyZz+7DSeoKPAFzuCE4yeI9OqQK+sha4tw6xKQNBI979tv09tuUbRkO0EugR/ffpsUoWKRUQBRfLOZaNx2udVbtVWRnqiCF/8hjZkJDfq8gKPdhHxBwsICb4vRUaZ+YjGCrp2ouKmOHhUKaqVPdzf/Tqc5Px0dBDDpNAHUTp1/05rWtLXWBCp3kzVSfvHCC3zSCxn5aJTLv1SK733gA2v7+tyqsW1VbEKWVTBis6klLsmkekxJ4vtiCdzaShADrCzLfQ9F8NEnCwh/w4YLkxZk0xKKRQ5t71464MVFBm5EgVE2S9By9Og2V+rhMHDqFCSHHZ6Dvdyp6H0kywxrnDpFJFRPJXgHZVCrmxVHIpyqzk6Vy7pnD52838+IRT3RuHW51bsVjPRH4atkgfCNRe6qTzkXiuPKGxFEAwUYKhU4Smlo0naYvD7IPtuKrs2RI5yeRvRiGrHq4iSzWe0obTIRkMzP834QnBW9nmXJTbG3pjXt5lkTqNxNtln5hdEIfP3rfHKL5SDAp29LCz3Vyy9zGb3TUpo7UhpSY4I9+tZbBCoaDZ28Tsdz1Gq5b62Wr2m1/JwoyRDH9njQ4QH+pQ/45jeJIRwOOiO9Xt211crCIiHk5XYzrbAtCwTozXt6uPPqhowAI1yzs9yuFqjsYDvfavwo9EU8Hu6ypYX/h8N8zeXi+a8nGreGXhILwH3tNKQf7RyYisUAnxxFce483l5yo6SzYSltgaOkRWs4AqTTkAaH4HLZsLTE1NVO6sVUFydNT/NeyGbV0vCuLkZTZJnHtlhu4B5pWtOa1pA1gcrdZBuVX0QiZFlOTdHLJJPctlRifDoU4tM1naZXam/fWSnNHSsNqTJJIoP11Ck6abdbLU+ORBhJMRiIMOx2NSW0Ttvfjg7gYx+j4xYqo34/+Q5CR6VYJOYJBhlpuOW8gypkoQwOIZIyIBfTQtbLcA9aIE1tLTJVjR/zeVU0DuB52mzcJpvl7bGZaNxK2snvB17feTA1NKhAOj2JcCoLjdOOIXse8UkzrkYc8Awp0MSiQMAP44AV0SjTQKJUeadMRI9efpkKw0tLvG29XqaA9HpVSr+/v0mibVrTbrbtAP2svk1PT+Mzn/kM+vv7YTKZMDg4iH//7/89CoXCqu3Onz+P9773vZBlGd3d3fiDP/iDmzWku9+qE+jVJuprFxboxAMB/iwvq92GCwWmHhYW+PP22yqX42aOTdh2pVI7OqiNMjzM8ywWGWXp6WFIoK1NjeK0tJBEu0HbXxEV+PjHgV/9VeIgh4NDs1j4OxSi47sh3oHXy7GFQhx3tSkKX29rW6u+ex1ZLBr78fVXO/EX3+/BX77QhW/8uAPfG2uHX+5XI1O1pigMjyws8LeirMKPIlWRz3Nzk4nnmUwS/9UTjevpqQMCatN8ViujWSLNF4vx/drzXsdWBeNS7BWg99ih11ZQLGsw4EujWNRgesmMrMGOSjSBeDCLWIyX/GbwQ3w+3iOf+ARTO488wsuVTvOns5PbNEm0TWvazbebFlEZHx9HpVLBn//5n2NoaAgXLlzAL/3SLyGdTuMP//APAQCJRAIf+MAH8MQTT+ArX/kK3n77bfyLf/Ev4HQ68cu//Ms3a2h3r60nbS/KE/x+Lv30egITjUZNqKfTqpxmLrfzUprbld1vxA4fBr7wBeDv/54SoZkMY/CSpGqqOBzAT/80JfQ3WcmLqIDHw023o2m3qXk8jOx897skgrjdqu56JELAVS/yk8vh7JQVXxs/gPmIGWZjGWZjGfGMDqG4AcGIHsdbluCrjUytw2mR+0ZhNHqRzTIC0NamVoSLeRApFI2mQdG4HU7zrQrGxdgrwNamQaujgIWwjHZHHj5PHm32PNIFGbFYGVEdcOAo8JGP3Dx+iEbDaq9sVo2gaLXE+8nkDoDZpjWtaQ3ZTQMqTz/9NJ5++umV/wcGBjAxMYE/+7M/WwEq/+t//S8UCgV89atfhcFgwP79+3H27Fn80R/9UROo1LP1pO2jUYpN6PUqENFqVc0RUSmTz6upkkRiZ4HKjcjuN2IdHWoI5K23GJEQXqNKMGzN/jcp095pTbsVkyRGdpaWgIsXV0dANBou0+tEfhajJvzl6YOYjssY6slC1leQL2kQThqRLZaAQgFjlU6cMMpq8+YNOC3uQBA91p/BhN+DoSGmuKJRfsTp5Dnv3avSmhoSjdvhNN8qnZbrIR2pkMegN4NYWofZZRNkfRmHBxLIp4pY0Ghw6L0VfOQXeFvcTKslEWcyHOuePTuj29K0pjVtc7ulHJV4PA531Yr65MmTeOyxx2AQVRoAnnrqKfz+7/8+otEoXHX6weTzeeRF7BqMyryrrF75hVCkam2ll1EUtcpElKwUiyR0inazglF5s8e2YyEK0Knv39+4PrrfD+X0aRQuTaKSzkJjMcGwdwjS6OiqsWy53LdRjRqfD/jkJ4HTp6kal04zv7R3L4FVzXwoCvDKeRfm8jkM2RZgNlAf3mSoQHbl4I8YYUrlMNPWgwjc8IgPbVBtJU1OYqT1DILOn8LkFcBnS+Jwbwnj00ZMTZthMEjYvZspjIZF43ZUAa4mGDdog9TaCiwswO2TMTKQwKuX3DDqyogkDZBjETxwvx0jv2CB7yaDFGE3Dcw2rWlNa8huGVCZnJzEn/zJn6xEUwAgEAigv79/1Xbt7e0r79UDKr/3e7+HL37xizd3sHe61T45IxHG8xMJVZUqn1d/FIXMSeE4TKabJ6W53af6VgTqGkEWfj+yf/UtJC/OIlGxogQddEjBPvEqbJdnYfrkh7cHnLZaNuzzAc88wzTPJucWiQDTMxLMHQ7I2dBKbyDodZCKJbhKccRhR9TegVxeUj+0SRrGF7uC43u7MfZSHLNvZpHPKegzSjgyYMPwk93oHW3dmuPd4TTfqmDclASfdwimSBzZ6WVE4MMju5fxYG8AztQC5MNWuD+yH1LHrUUJ29GuaVrTmrYztmWg8lu/9Vv4/d///Q23uXTpEvbs2bPy/8LCAp5++ml87GMfwy/90i9tfZRV9tu//dv4/Oc/v/J/IpFAt2gl+26y6ienLFPZdXycERSR3hE9cERkRacjC7Cjg8qwN4sFuNWn+uIim7dMT3OsBgPTOdsVqFMUZF54DZHXJ5GyeCG7TTAatSjny4hEDCi8Pgl362sw/9xHtrbveimWTIYRk9Ongfe8h/Pq8azeb4PzIYJgZo8Fec0QTNFFIJ4A0iVAq4OxzYFgpQsap1kNVmSzBCsGg6o3U31skwm4fBm+7D/ihB2IvL8XOa0FcjkNd/I0pHkncN9xQNoCaLsJab7VwTgXgq33w1iZxbA0i5HWBfisZWDf9kqfm9a0pt3dtmWg8u/+3b/Dpz71qQ23GRgYWPl7cXER73vf+/DII4/gL/7iL1Zt5/V6EQwGV70m/vfWVkNcN6PRCKOor2waze2mg8zl+DM5yTSPKOMwm1ld0trK36Kz3u2IXddGTmZngb/8S0aEhEBdoUBQtU2BOiUcRuLkBWT0Dlg7bBBkDp1JB2uHDZnpLHQnL8B0/HFI9cTW1ht3bYolEmH96vg4x/+DH/A6PPLItkT1RLAlHgciESvkwV2QclmgTKCSU0zIzEjo6wPcLgV45yJraE+fZiTNaiVbdmBABaGZDPk8Gg2kQ4fgkSQARQAGwLtNIT7gpqT5VgfjHJCNB+BGB6R8M9/StKa9m23LQKW1tRWtra0NbbuwsID3ve99GB0dxde+9jVoaiQ+H374YfzO7/wOisUi9Ho9AOD555/H8PBw3bRP09ax6hUuwId6NsvleTDIqIrdzgf944/fHGXaRqw2bZLNsuNxLscIyttvEwiI6qR8nhGMLQrU5QIx5EMJGHp6gFq/JgGGNgfys7PIBWIwNQpUalMskQibH16+zMhVZyfHu7wM/O3fEgD87M9uKSIkBOYED9UfkOBymWG0XMefU0B/n4Jj3suQ/uT7wKuvkm+UTvO4/f1Mx/j9BEtut9oWenBw/QqdmRkV3G4FENwE8sbq4JMEoJlvaVrT3u120zgqCwsLePzxx9Hb24s//MM/xNLS0sp7Ilryz/7ZP8MXv/hFfOYzn8EXvvAFXLhwAf/5P/9n/Kf/9J9u1rDuXate4cqy2r1t715GUYaGbn6vn42sNm0iy8APf8i2vRYLHWUySWdZ3R1ZrycRdQsCdSXoUIYWBpQArI2+6VBCAVqUtnL7V1e6CN2auTlGEaqjF/k8K31+8AP+PnGiLnG2ntXDm4kE/89kgP62FD7V+jI6/tvXWUmUTDLVIwDp5csETHo9gcuBA2THtrevVcYVls2y+U88znPbqrpsk7zRtKY17SbbTQMqzz//PCYnJzE5OYmurq5V7ynXhaAcDgeee+45/Ot//a8xOjqKlpYW/O7v/m6zNHm7Jla4Dz1EB5TN0vkIZa/bFTavlzZJJOgcrVau6DMZqncJrkUmo/Ivkklu06Auh9bbilJ7J+TQPCp9A2vInppQAKX2Lmi9jUUGAayudKlUCFKqOSGJhFqC7HYT2MTjVAsOhRqOCFXjTXHKWi3Q54jgWPYH6Lj0Iucxk+G8xmJqii+XI2DxegkAW1qA97+fQK9ehU4kwk7T4TBBbFvbttVlm7bWymVm5ZaXeSlGR9UuD01rWtMat5sGVD71qU9tymUBgIMHD+LHP/7xzRrGu8/uxBVuvcqUYpGOPp3m35KkllJrNIyyxGIqaBHphQbM5DFD+9BRZL67BNviDEruNihGI6R8HrpICMmSEdqHjsLkWSfKUM+qK11cLo5FksilURQqAet0jF4ABA+VCoXpotEt8UDWZFSMCtynTkI6M8n9+v30fhoN56ZQIMATKb9KhWkgr5dKxd3djLZUV+iIqFAgQF6N18v3bqSJZNNW7Pnnga99jbeLKA4bHqbI8pNP3u7RNa1pd5c1e/007eZbPYEwvZ6OvVxWQUq5zNcAOlvRcFAI2DWoyyFJEtqeOITppQyKF9+GPRKFDmWUoUVE04bSg/eh74lDkLbigKvzMoL4K0BUKkUekFDLFW0iZJkAYhsNGVfhzXAEmJvlHFy5ovY5Kpd5XElSq7sAghizmdGeuTm2FQiFSPx1u/l6NgtcuMBrotUS/Hi9vA7XuSvKzCwik1HkzO4ml3UL9vzzwBe/SHza2Unsl0px+oWyQhOsNK1pjVsTqDTt5ls9gTCbjZEJjYagRTSbMRjocIU4msXCp3xf35bKqW0+G/o++TD8p3sRvDQLJZ2FZDHBurcHXaMdsPlsWz8Prxd48EHgzTfJAUql1JSVOCdFYapKo2Ekw2YjqNhqQ8ZqE9Vcy8tqJEqnU/cn5k9RVKAkSUw9iU7Tej2jJ+fO8TP5PMvBTSa1TXBnJ/VeBgbgzzoxdtaE2biE/DaoK3eabUWm50asXGYkJRolHUwECV0udnm4eJHvv//9zTRQ05rWqDWBStNuvtUTCJMkVqKcOaM6dlGeLFI/7e3kfhw8SOn8LXoWm88G6zO7kX24G6VcCTpZB5PbtLVIirDqiqVcjtET0bdHlglYkkm12mp4WK202W5DRmGyTCASi3EuRbMeAVQqFc5ZsUigp9EQdCwu8vivvsrPP/oof1+8CHzvexz70BDL1rNZ8lqWl+F/7ON4duE+xMJl+I5qYbrLqStb1ei7ETt9mvPU2amCFGHiskxMcLsHHtjZYzetafeqNYFK026+rScQ5nZTfC6b5TaZDB2pTkegEo9TE+RXfmXbTV0kSYJ5K1wUYdVL8FgMOHVKbS7o8RBEabUEDcUi31taIoAZHmYjRbf7xhsyAvxcezsBR2cndVvyeZUfk8+rDSjNZi7fW1romR0OVv7s2qWmq2Zm6K1bWggE29oY6bJYoEzPYOz5ZcScWQwdtkLyUodmR6krostzIMD/vd61Ink7ZKLYTDQVFEVS4+M3B3QtL/Ny1OssAPD1xUVu17SmNa0xawKVpt0aW08g7Phx8icCATUikcnw5+BBgpQjR27tWGujJ+fO8bX2dkYs9Ho69/5+ej6fD/iFXwBee42fHxoiYEildqYhoySxZOT555kS8/mgBIKIZEzIKUbIugzcugQko4Ggxunk/MoyPWNHh3psv5/gqq0NSrmCyHQCuXkFstsItymLiLkLs5MV+N6TgDR0aNWYt9EYecVWcN9MEPKpl+F++xVISyG+2d6uNmncQdQgis1mZojPJieJKfV6FaPtNF+4pYW3dSrFy15rqZSKEZvWtKY1Zk2g0rRbZ+sJhAUCdepx+5juudntcWutVu9laYkeLpPh+8PDBCvz81ym79nDyM9TT5GUIABOKLSzDRn37aNK78svw28ZwpjuAcwanMgXNTDKCnqUaYxYJuHTXucB2e0EepXKahJzNgsUi/DDh7HUIGbLRuSTdhjjWfQYA/AZo8hrzTDt7qobAdpiY+SVKR0bA2bPx5A/dRHG+SR67P0Y2dUKnzXJufrudznXn/zkjoGVSAQ4f57HL5cJHMplTsHVqwzanT9PjLRThXKjo7zk584xmFWd/qlUgIUF4NAhbte0pjWtMWsClabdWqtXPn2ntKet1XsBgDfe4DJ8YICAJBSCMjiEiGMAucUIZF0U7i4zpFyOaZntnEelwlLheJzebXBwLcFBkoAnnoA/pMWzC1rEnEX4nH6YshFk0xVM6B5A0PEAjg9MwDdoJoB68EGq51aTmE0m+BUvnp3bj5jihM8chKlHQrbsxESyC1PFDHIOIOvsQL3sxVbpNiu4L6rAF5mCKf0OslYdJrT7EfTncHzwCnx9ZuZDLl4keeOZZ3bk2gtAUipxWufnOcWi9VUwyABVNnvDh1oxrZYlyF/8Ik+nuupnYYG3w6c/3STSNq1pW7EmUGnanWF3gv5Lrd7L/7+9O4+O66zzhP+9S9WtW6uqSkuVFm+SY8dxHG8kGNKEJSQ4OTOTHMg5MMB0aE4gmfQLnM7pCTkwDemZJjTM9LwDMwP0zMHD6eYlPYQXukknZCHdTjeY5I23WF5kW7a1VpVKtS/33rrL8/7xpEqStViSbS3W73OOTqKqq9KtKyX3p+f5LcUiD1rqiQ1+PxIpEUeM9RjU22DoDMpAAetu9mL3vSriHYt4H8eOAT//Oc+wrAc3W7YADz7I81wmYbE4jrTei3xnCj0tJyGkPEDBB7+nhh5XAefFm3Ak0Ib73ueDsGc3z/24dGlKEjOLxXFE2Yd8QkBPUz+EYBBQ3fALAnp8ZZw7VYPWvBGjdhs2s6sbjDwl7msrQegdAGDDH/Gix5XF+VwER5LtuK/nLIRIhF//06d55dEifxcmpxaNjk4MFO/v54/5/XzrxzT5Qs65c3wh77KelFelXnpc76MyOsqDu9tuoz4qhCwGBSqE1F3e78U0+Z++kQiQyyGhbMCLY1uQt5oRb9aheg1ol8bQp92F1Bth7I8scNfi2DHgO9/hiaX1UuZSiT8+NAR84QtTgpVsFhgsRxH/YAQC6+RlyLUa4HJBME3ETQWDmoLsu32INr8TYVyWxJw1gxgM34b4yD9BKJeB1ha+oqNpEMbH0d7cjNqOLXAp4lUPRp4S9xnmlHJqQQDi/jIGCyFkNRVRj8Ofq1QWXcZ9+RBuQeBBUj1QmLy45XJNFFOdO8dHI13LBbwPf5iXIFNnWkKuHgUqhNRd3u/F5eIfkQhYVcORgQjypg894QwEiEAmB39QRM97W3E+LywsMdNx+EpKJsNn8lzecKO3lz+/Y0fjuUYc5RUAKTjtJVUbSF0CdGPSg5clMeupMgzXzVA/sA8YT/HvPzzM3+fGjVBv3wdV7MCdd/LA5GoGI0+J+xzXxH7RO2XUqmwiZfugW+/0egH48sciyriPHeNDuIeGeB6z18vfUrXKU6Cam3kcKMs8OCmXG28Z6fTCk4PnQ5KoBJmQa4ECFXLNLFVTrevm8n4vgQCv7hkeRrZ9Owb744irBQi6jwcPbjewfTuEdesQryywGqa/n3+frq6ZG250dfHn+/t5aTFm7ps32az5I5NygDyJGhRfAFqHD37fO63/6831YjFoVRFKnk9x3rXr6n6eU843EAC6OoGREbBSCSVfHHndA9ORoIgm/0aiyIdoLrCMe3SUb7NcvMi3cCRpommwx8P/XZImpgtI0kQ1dHf31N55hJCVhwIVck0sZVOt62amfi/r1wPJJPSLSRhNO6He4gNkgW/RRKM88UAQFl4NUyjwgwOzdMgNBCayP98xU9+8uivmj7yTOxOJAOsG6q8hQJhUVXX5a1xt2tDU8xUgdPcgey6L/uMljJlNSNgxdAYK+N1RN/aE3Ii/fwvfH1lANMQY3+45f57/zl28yLd9JIkvTMkyf9ww+Pvy+SYqfwKBicrtxfbiI4RcfxSokKt2eUVvPadhVXYyvbzfi2EAGzfCEwSUsyFohgO/C/xP8e7uRlSw4OazoRA/uFSaueFGqcSfD4UaD83WN28h+SPX4jXm6/Lv5fFEcMpzJ/JNSWB8HOuEQdwsjOCsuQljLe/F/g90Ix5vW9D3qJcg53L8fQSDPDipVnmVjcvF28oYxsRkAZeLL1ht3Mi//mp68RFCrj8KVMhVubyit36DW9VDeGcol440hbHu/5TQdwbo2SxACAYab2hRzWe7u/kXHDs2c8ONoSGeSNvdPe3UZuqbt5D8kWvxGvNV/16HD/Ou/SNZP9p3dKPVH8emcA6R0HawpjDOpwI4MiLgvtsW9nuiaTwgcZyJ4qzxcR6o1FdORJG35ens5B/1XJVk8toGZoSQ64MCFXJVJld2ALwctN79s960dTGdTJfdZfseAoDd7w8hpQHnx4C4dJUrEaLIS5CHhnji7OSqn6Eh/r0ffHB6/gquTduZpWxdE4/zpmqnTwO33AI0NQkIBHwQBB8Afm3j0uJ+TzSNr5Y0N/O8YF3nv38ez0TxVjrNA+ebb+bpONns9QvMCCHXHgUq5KrUKzs0jd+IhoYmbnxdXfwvWcO4MZIVr/lKxM6dvAS53kelPmxw584Z+6hMdi3azixl65r6AOeOjplLdBeS4zN5VFAyyV9XVXlflEKBB1z16p5KhW/9dL7TaPe++/i5rMpkb0LWKApUyFWpD/E9fJjfaByH/8+fMb4kf/Ei/yv6RklWvOYrETt38hLkK3WmXeUWXbF0mUQCePVVPiMyleJBRzrNAxPD4JevVuMBimnyRapNm/hqytAQ7yXX0XF93iMh5PqgQIVclXCY/yXb28v/Op/cq6JU4o+3tMycL7paXfOVCFFslCDfqK6qYukdiQTwk58Ab7zBV1HWreOPl8u8RJmxid8zQZjIV96yhf8ODgzcGCt7hKw1FKiQq5LN8mV4RZl4bPJNSFH489ksTYxdy6622ogxvmp36hQvMZ48EPq223jybCrFW9ts2dJotttYUdH1BVZlEUJWjBtrfZksuXq/sB07eCCi67wCSNf55zt28OeTyeU+U7Lc6jk+W7bw35FLl/g/t2wBPvKRuXN86mOAHGf6VlsgwJvThUI86Mnl+HFdXTz4CYf54+vWURkyIasRraiQBZvcgTaX44/5/byJq6ZNNNxSVf6Xbja7vOdLVo7F5vjoOg94gamrd3XRKB8YXSjwbZ6bb+b/1HW+gkNlyISsXhSokAW5vAOtYfC/iisVfnPweiduBozx/JXWVj7Il6xg9ehT0/iHqvKP61Aas5gcH4+Hb/kAU+dG1hkGf/6mm4Bt2/jv5MAAlSETciOgQIXMW70D7cgI/wtV0/jy/fg4v8eNjfGO852dPFcgm+WVF/v2rbIeKmtNPfp8+23gwgWeBR0M8uSOW29dEXf5SIQHwn19/Pdqco5KPcYSReCOO/iKTS63imdOEUKmoECFzAtjvCz0N7+Z6Ek2NsZvDuEwr8IoFHg58tgYD1b8ft7o6+676UaxGEsy5HF0FHjuOf6DGx/nkaWq8lKaU6f4D7O/H/jYx3h0sEwEgY8BOnuWV/1cusRX6gB+iqbJf9f27OG/kxQYE3LjoECFzMupU8AvfjGRrFgoTOSiaBq/qVoWX36vVvnXPPAAv3HQkvvCJRK8yuX06YnhxjfffI2v5+go8IMf8Bry8XF+x/d6edRZq/EfbEsLjwoyGeDzn1/WYCUeBz7xCX5Kv/sd334EeMCybx8PiOl3jZAbDwUq5Irqqyn9/fzfgYleKcXiRIDidvMKjJYWXnWxYQPdOBaj3i/k1Cl+Hev6+viKwic+cQ2uayLBV1J6e/kPLpXiP8hCYWIGgiDwbmodHfy4554DHnpoWX+o8TjwqU/x6qF6JVksxldQaNWOkBsTlSeTK8pkgOPHJzrO1qfTTp5Ga1n8plrvl2IYfEWgHtiQ+akHhW+8MVGKG4/zfzoOf/zVV6/yutYnSWYyPEjp7+c/OMviy2Xj4/yftRo/5vx5/kPOZPjXLfMPVRD479j27fyjuZmCFEJuZBSokCtKJvnKSWvrxGwfx+EfbjcPXEyTr6pYFh9ZE4nwnQQqTV6YTIZva7hcfJdFVXnOharyz10u/nwmcxXfpD5J0u/nyUbj4/yFq1Wem2Ka/J+axh/PZvlxPt/E5EBCCFkiFKiQeWtr4zkp5TIPThibyE0RRZ7w6fHw+144zI+hluULk0zyXZjW1umrBILAH0+lrrKBnq7zj0KB/+DqP8hqdWKJTBD457bNI1JJ4sfXv5YQQpYIBSrkimIxfoO0bd7tUxD4SgpjfHcA4DmY9YGEHg9fjq8HLmSF8Xh4dDk6ykuQHYcvk9VN3toxTf78xo08r8Wy6IdKCFlSFKiQK4pGeVVFPWk2FOK7BvVVE1HkAYos8+2JjRt5UEMtyxeuHhSOjU1PBXEcvgPj9U4EiosSifBvkskATU38B6qqfCVFFHlwIor8c4+HPx8O8+Pb2uiHSghZUhSokCsSBF76eccd/B7V3DyRn6IovDfYtm08mIlE+OMdHdSyfDHqQaFp8gUPTePXenwcePNN3o/NsnhC7Qsv8EWOBRMEYO9e/oOr56pEo/yHGQjwD7+ff97czP99cJAfv2cP/VAJIUuKypPJvNR7WBw+zCtP3n6bpyq0tvI/xi2LrwIEg8Bdd1FPi8WqB4XpNC9PzmZ5qsjwMA9etm0DPvABfs37+ni+yv79i7jW27YB99wDvPQSXz3x+fiHYfAVlGqVr6Z4vTw/xevlx2/bdl3eNyGEzEZgbHUXkBaLRYRCIRQKBQSDweU+nRtevVvqwAC/UeZy/N5mWXxXYM8efi+jP7qvzuSGb8eO8aqrnTuBnp6JnRfGeOXwli28bfyCr3kiwZdl/uEfeGASifBS5Xyeb/Vs2sR/2F4vj47uu4+iT0LINTPf+zetqJAFqQ+Ui0aBXbuWoMX7GhWPA/ffz4MQy+LXOxaben0FgR9XrxhecNv4+ihjtxt4+WW+jNPWxj8A/nkwyFdSaImMELJMKFAhi7aYKbhk/gSBL2ao6vRyZcb4zCVd5zmumrbIb1Jv9bp7N/DWW3z/TpJ4NjQtkRFCVgAKVAhZwTwentOqaTynFeCrJ/39fMGjXOazgMJh4P3vX2RMIQjALbfwL17iJbIlGbxICFnVKFAhZAWLRHjvmqNHeSVVOs1zgwyDBy6JBL+x//KXwGuvAR/6EB8GuajZgUu8RJZI8I78gwMMRrYCRTKxboOI3XcFEW+naIUQwlGgQsgKlkzyhOVjx4Dnn5+YWh0O85UUt5vv3tg2H3L813/NA5nPfIYn365UiQTw4otAfqCAeLUfajEFrcrQ91YIqd/5sP9BFfHNflpmIYRQoELISlW/mQ8M8DwVRZnoaJ9I8Kpir5dv/0SjQGcn//e+PuDAAeDJJxe5snKd1Wci5gcK6Mm+CaHK9678zQp6Mhmc/90wjrw9hPvuqkBoa+WdA3fvpmReQtYoavhGyApUv5nncjwwURS+QtLRwauG6+MJbJsf63LxYyQJWL+e9105eHDZBx3PKJvl2z3xaj8PUuJxHolVKhBGRhD35DBYiSBblHlPl74+HrEtqrsdIWS1o0CFkBWoPuA4EOB5KR4PTziVpInu9pUK79FWrfKZS6Y50ZvN6+VbQStx0LGuA0a2ArWY4ntYgsAjqmQS0HWoLX4Yvij0dIk/3tPDe7scObIyIy9CyHVFWz+ErEC6zhNmbRu4eJHfy22b36/rj9v2RCWxbfOviUYntoQcZ2UOOvZ4AEUyoVUZ/M0Kf1DTeAKO3w/NdkNRAA/TePR11Q1jCCGr2ZKsqBiGgZ07d0IQBBw7dmzKc2+//TZ+7/d+Dx6PB11dXfjWt761FKdEyIrm8fB795tv8jk/ts13QVpa+L8Xi3wVpVbjAUmxyL+mrY0HM/U5gks66Jgx3tRlZIT/c5bVj0gEWLdBRKIaAtPfmdpsW4Btg8kuJMp+rPOmEfHX+NIRwLeGDGNlRl6EkOtqSVZU/t2/+3dob2/H8ePHpzxeLBZxzz334O6778b3v/99nDhxAn/wB3+ApqYmfO5zn1uKUyNkRdJ14MQJPu9HkvjUZE3jN/nubv64bfNZP7HYxFDjcplvB3m9PFdlyQYdN2qNB3lAoSizJsEKArD7riBSb/hx/nwO8R4RquCC5niRSAcRDmjYrZyC0NrC974A/uYVZYkjL0LISnDdA5UXX3wRL7/8Mn72s5/hxRdfnPLcj3/8Y9RqNfzwhz+E2+3GLbfcgmPHjuEv/uIvZg1UDMOAYRiNz4vF4nU9f0KWWiIB/OxnfCekpYWvmtg2bxpbLPLVkg0beG4KMDHomDG+K1IPUpZsenWj1jg/kRiraXNOTYy3C9j/cAxHDiQxeMlCyhuGIjdji30Wu32jiLc6PCKr568kEnyewJJFXoSQleK6BiqpVAqPPPIIfvGLX8Dr9U57/tChQ3jf+94Ht9vdeOzee+/Fn//5nyOXyyEcDk/7mmeeeQZPP/309TxtQpZNvdonk+ErJT4fD1BcLl4BVCwCssybyKoq8LGP8bSNS5f4FlA4PBGkLEk1b6PWOM+TXuuRkd/PPz9/nj8/w9TE+M423PfkDmQPnoB+6SQ8+SQiIycgeBRgy24ekZXLPEgJh5cw8iKErCTXLVBhjOHhhx/Go48+ir179+LSpUvTjkkmk9i4ceOUx9reGYiWTCZnDFSeeuop/NEf/VHj82KxiK6urmt78oQsk3q1T0cHD1Dcbn6/7+jgwwnLZb7CsmsX3wXZu5cvMixbG/r6Ccfj07/pPJJghfY4oh+PTbyBfJ5nDw8N8ehLUfhKCvVRIWTNWnCg8uUvfxl//ud/Pucxp0+fxssvv4xSqYSnnnpq0Sc3E0VRoCjKNX1NQlaKerXP+vV822dkhN+f6wuSfj/fTSkUJnZClnU4ZP2EVXXm51WVn/BcSbCT30BHx7LMHCKErFwLDlSeeOIJPPzww3Mes2nTJrz22ms4dOjQtKBi7969+OQnP4kf/ehHiMViSKVSU56vfx6LxRZ6aoRcNdu2kTicgDauQW1WEd8ThyRJS/b960MIdZ2naOTzEzsfisIDlFwOuO22FbITMtPUxMkWkwRLY7kJIZMsOFBpaWlBS0vLFY/7zne+g//4H/9j4/PR0VHce++9+Ju/+RvccccdAIB9+/bhK1/5CkzThOudMsRXXnkFW7ZsmXHbh5Drqf+Vfhw9cBTZviwsw4KsyIhsiWDXZ3ah+8PdS3IOkQgvlunr41s+e/ZMTErO5Xjgsn078NGPrpCdkMtPeHLkREmwhJBr4LrlqKxbt27K5/53/trq7u5GZ2cnAOBf/+t/jaeffhqf/exn8eSTT6K3txf/9b/+V/yX//JfrtdpETKj/lf6cfDpg9ByGoIdQbj9btTKNaSOp3Dw6YMAsCTBiiDwlZJUiuehxuM8HyWd5ttAO3fyIGXFzPCZ6YTrVT+UBEsIuQaWtTNtKBTCyy+/jMcffxx79uxBc3Mz/uRP/oR6qJAlZds2jh44Ci2noXlbM0SR90H0hD1wh9wYPzWOoweOYsMHNyzJNlA8zit6L29LcvvtKzSn9PITTqUoCZYQcs0IjK3u4RnFYhGhUAiFQgHBYHC5T4esQsNvDuOFx16AGlXhCU/PpdBzOrSMhvu+dx86b+9csvNibJXllK66EyaELKf53r9p1g9Z87RxDZZhwe13z/i82+9GabQEbVxb0vNadTmlq+6ECSGrAU1PJmue2qxCVmTUyrUZn6+Va5AVGWrzLCW4hBBCrhsKVMiaF98TR2RLBMWRIhzHmfKc4zgojhQR2RJBfA/lWhBCyFKjQIWseZIkYddndkENqxg/NQ49p8MxHeg5HeOnxqFGVOz6zK4l7adCCCGEoxwVQjBRelzvo1IaLUFWZLTd1rakfVQIIYRMRYEKuS4YY9CyGizdguyRoUZUCCu8AqT7w93Y8MENy9qZlhBCyFQUqJBrrpQoIXEkgcJgAbZhQ1IkhNaFEN8dRyAeWO7Tm5MkSUtagkwIIWRuFKiQa6qUKOH8i+eh53X4437IqgxLs5Dpy6CSqqBnf8+KD1YIIYSsHJRMS64ZxhgSRxLQ8zrCPWG4/W6Ikgi3341wTxh6XkfiSAKrvMcgIYSQJUSBCrlmtKyGwmAB/rh/Wj6KIAjwx/0oDBagZZe2cRohhJDViwIVcs1YugXbsCGrM+8oyqoM27Bh6dYSnxkhhJDVinJUyDUje2RIigRLm2hHzxhDrVSDVbOg53RYugWzaoIxtqgqoNVYTUQIIWTxKFAh14waURFaF0KmL4NwTxhaVsPYyTEULhZQyVSg53SoERW1Ug1tO9qw/q71CLbPf5Dkaq4mIoQQsjgUqJBrRhAExHfHUUlVMHBwAOlTaZTHyjByBsyqCUEWYBkWLrx6Aam3Uxh+Yxg7H96J+M4rt6anaiJCCFmbKEeFXFOBeABtu9qQOZdB7lIO2rgGLa/BqBjQ8zoqYxVUxiqoZqpIn0zj2IFjKI4W53zN2aqJZFWG4zgY+u0QTjx7ApZFuS+EEHKjoRUVck0xxpA5kwGzGdSoilK1BFESIUCA6BJhmzZMzUQ1XYVLdSF3PoeBgwPY/vHts+aazFRNlDyaxIVXL6A0UoJVs9D/cj8G/2kQ73rsXfNqd0+5LoQQsjpQoEKuKS2rIXcxB7NqQmR8wc5xHLhUFwRRgCiLsHQLjuXANm3UqjXkL+ahZTV4o94ZX/PyaqLk0SR6n+1FrVyDGlGhelToOR3p3jQOPn0QAOYMVijXhRBCVg/a+iHXlKVbMCsmHNOBIAtwTAeiIE6sVgg8l8U2bYiyCMdyUCvX5ixZnlxN5NgOLrx6AbVyDYGuANwBNwQIcPvdiGyNQMtpOHrgKGzbnvG16rkumb4MPE0ehDaE4GnyINOXwfkXz6OUKF2Py0IIIWSRKFAh15TskeHyuSC6RdiWDcElgDEGx3H4AYxvuwiyAMdyIMoiXH4XZM/si3v1aqJyoozs+SxKIyWoERWiKIIxBku34PK64PK4EOwIItuXReJwYtrrUOdcQghZfShQIdeUGlER3hiGS3VBdsuQZKmx3WObNq/+kQRIsgTJJcGluhDeGIYaUWd9zXo1kafJg8yZDKyaBckjwTEdmGUToluEGuY5Jm6/G5ZhQRuf3v2WOucSQsjqQ4EKuaYEQcD6u9YjsjkC0SXC1+qDrMoQBAFm2QREwKW64G/zQ3SJiN4Uxfq71l8xkTUQD6Bnfw+ab2mGIAjQczps04Y74EYgFmjkr9TKNciKDLV5euCz2M65jDFUM1UUR4qoZqq04kIIIUuIkmnJNRdsD2Lnwztx7MAxZM9l4ZgO71QrAGA8IFDDKiI3RXDbw7fNu+lbIB7A7f/X7Rj8p0Gke9Pwd/jh8rgaQY7jOCiOFNF2Wxvie6b3Zpmpc+5klmZBUqQp21CUeEsIIcuLAhVyVWYr843vjMP3pA8DBweQOp5CcaQIy7Dg8rgQ6AgsqjMtAMiyjHc99i4cfPog8v15BDuCcPvdqJVrKI4UoUZU7PrMLoiiiGqmOuW8Lu+cO3kVhzGGcqKM6JZoYxuqlCjh3AvnUBrlOTGeiAeiLFKTOUIIWUIUqJBFu9JqQ7A9iO0f347ue7phaiYszYKsynCprqvqW1IvPT7ywyMYOzHWeN3WHa3Y/Qe70bq9FedeODfjedU75+bO56Z0uC0nyvCEPYjvjkMQeALwhVcvYPjQMASXgPxAHpJLgrfVi/DGMPQsT7z13zc932WhqKcLIYTMjgIVsiiXt7SXPBKq6SpG3hxBtj+LbR/bhmB7EIIgzNofpX6DNjUTZtWEZVg8qTXmhzfqnfNm7W3xIrI5Am1cg1EyoAQURDZHAOCKrfZ79vdMBFgpHshEt0SnbOekT6XR/3I/GGPwN/khKzIsw0JpuAQ9p6N5a3Mj8Xa29zff60hbS4QQMjsKVMiCXV7mq+d0jJ8eRyVdgV2zMdY7Bi2jYc/n98y6tVO/QadOpDD29hiKw0U4jgM1pCK0IYTOd3di092bZrxZJ44l8OZ33kQ1U0Xzlma4A27USjWkjqUwcmgErTtaseGuDY1Ap15+nDufQ+JIApvv24zN922edRWDMYbRw6MwigZabmmBKPGcc5fKy6jLiTJKoyV4o945+79cCc0vIoSQK6NAhSzY5DJfPacjcTiBWqUGNaxCivCS43RvGqefO41tD22bdrOt36DzA3mkT6WRv5TnPVcEAcxhYGCopquopqvY/ontU77ecRyc+fkZVDNVtGxvgSjyIMIT9iDsCuPSry+hcLEAvA88efcdl5cfe6PeWVdCtKyGSqoCNarCqTkQVXHK63jCHpRHy/CEPHP2fwFm39a5PNibMag6nID4bpFXKtGWECFkjaJAhSxYvcxX8kgYPz2OWqU2pTeJElJg6iaqmSoSRxLw7fdBz+mwdF5VM3p4FPmBPMb7xpE8moRe0sFsBjAAAuBp8iAQD2D0rVFEborgpvtvarx2rj+HTF8Goa5QI0hpcPj3roxVUE6WEWifGiDJqgw7Nb38eKb3J8oigu1BlBIl+D1T81AktwQto8HX6puz/8tc2zqSW0JhsABfzIdaqQbbtCG5JN5pVxAgeSSce+Ec0qfTkFzSlK/1x/zTgh8AlOdCCLkhUaBCFqxe5ltNV1FJVxrN1uosw4LkkhDoCCB1IgWjyCcn24YN27QxdnIMZtVE9mwWRtng7fYFga80CAy1Ug0llGAZFkbeGEHXvq7G6odRMGDpFtyB6eXFoizC5XVBy2gwKyYAvqJRDwTsmg3RLV5xFUT2yJA9MvztfhhFA+VEma8WKRJsw0YpWYI76Eb73vZZg4Erbeu07WxDdayKwnAB5dEyTN3kFVFdAfiiPmTP8Q68Lbe0INARaHxtpi8Db4sXtXKtEfzUS60nP0Z5LoSQGwUFKmTB6mW+I2+OwK7ZkCJS4znGGPScjkBnAIIkIHUsBUuz0Ly1GbIqozhcROZMBrZtw6gasA0ePEguic8AqvEZPYJLgJE3kO3PwtTMxusrIQWyR0atVIMn7JlyXrIq8wnNlg3HcZDtz6I4XEStUoNjOjByBlq2t8Ay5l5Rqb+/9Ok0/O1+5M7nUBwpwuV1QXTxQGfDXRvQsq1lxq+fz7bO8O+GkXw7iWq22siBcUwH2fNZCJIAT8QDf7sfniZPo82/ElZw9u/O8u//gQ0Irg+inCjj3PPnwMCw/q71CG0IwayaSBxJYLxvHD339qBlWwutrhBCVi0KVMiC1VvaZ/uzGOsdg0t1QQkpsAwLek7nN+SNYaRPpWGbNiKbI42/+iUXb6lv12yYJRMMDKI4MbRQEPkgQ0mSYFkWX0HRJgKLcHcY0S1RJI8l4Q65p2z/MMZQK9cguSVcfO0i9JwOMEBtVuH2uaE2qxAgoP9X/XMmqgqCAMktYeD1ARSHio2pz/XxAJ3v4Ym+M938bdvGxdcu4twL5+CL+eA4/L1Mfm1fzIf+l/pRHCkCDuCJeFAr11Ar8Q+jZECNqmha39RYOapmquh/pR+lkRIEScDwoWEEO4OolWtw+VxgYKgkK3B5XchfyKM8VkY5UUauP4ee/T1o39NOqyuEkFWJAhWyKIF4ANs+tg1aRkO6Nw1TN/l2T2cAkU0RCJKAfH8e4U1hKEGl8XWSW4LL64Jt2mBgEDAxnBAAmMMgSDypVoAAJcjzXYojRcgeGZ6wBxs+sAHjZ8aROJxApCcCJaCgVqohcy4DZjHEdsZQHa8CDJA8ErSsBkEU0PWeLjRtbGpU/8zWAyVxLIHen/TCNmwEOgJ8plDVRGmkBMdysPXBrTPe9Ptf6cfRA0eR7k2jMlaBy+dCoDOA7g91I7Yr1jjONm1kz2ehRlTYNRvFwSIgAopPAQRAy2kw8gbKyTKKQ0XYpo3E4QTyF/PwRr08n0WRkLuQQ2mkhOatzXD73chfyqOcLMOxHahhFe5uN/S8juTRJKpjVaoiIoSsShSokEULtgex5/N7cPq506hmqgh0BOBt8cLWbYyfGYfoFtF8c/O0RFR/zM/zRSCCyQzMYnx7RwAECBAkvgWk+BWAAf2/6ofkkmDq7zSNe2eWTzXNk3WVgAJPkwdqVEXztmYE24PQMhrC3WGoURWiLMLIG9AyGpo2Nk2r/plsclVRfC9v/mZpFhzLAUSezDv4z4PY+KGNU1Zz+l/px8GnD0LLafC2eAERYDZD4WIBJ549AQCNYKWSrMCsmmjb0YbSaAmSIgECYNUsgPHtLeYw5C/lYRQMOJYDLaPBsR04QQeiS4Tb5wZzGPSCjlKihOZtzSgny3zVpycMADArJkzNhBJSoOW0a9agjhBClhIFKuSqBNuD2PbQtkZ1S3GgCEmR0Ly1GS6PCy7VNeV4d8CNpg1NqJVr8MV90HIarKoFx3YgOPwG6vK7+FaRCMg+mSeT6hbSp3kpsyAIUFtU+Nv9qKar8EQ9uOm+mzB2cgyZvgyGfzOMcqoMl9cFX4uv0Ra/kq6gVqpB9srQMhryF/MAMKVCZqaqIpd34j00rWtCpi+DXH8O0c1RAHy75+iBo9ByGpq3vROY2YBRMuDv9KM8XEb/r/vRsoOXU1fHq43XtGs2mjY0AYwHSaIoIj+YR2GgAMd0UKvUIEoiPFEPigNF5C/l0bShCaWREirpCsyKifEz4zCrJmrFGsKbw6imqyglS/zaahaYzeBt88KqWeh8d+dVNagjhJClRoEKuWqBeAD++6aWzHrCHpx/8fy0uTqCIKBpUxPG+8bRvLUZVs1C8RJv9uaYDmzThiiJMIoGFJ8CT9ADu2YjP5CHUTQgukRUx/iNPro1Cn+bH9nzWZx+7jRyl3KQXTKUJgW2acOxHBSHi6hmq+i4vQOiKKKSrqA0UkJxqAgIE4mz9QqZuaqKAB5oFYeLMApG47HE4QSyfVkEO4JT+rqYhgm7akMJKSgNlzB2YgyKT0GwK4hITwSVVIVve7l4jo4ECYwxmFW+jSapEhzTAWzA5XZBkAQYBQOlZAmO7cAdcMPb4uVbRCNFMIthvG8c5dEyasUarJrVmFydH8xDdsto392Onnt7rv8vBSGEXCMUqJBrYqZW+bPN1dGzOv/LvtmL0nAJKSWF3PkcqsUqRJcIbwtvn9+0oQlG0cDQb4Zg6RYsg/dv8bf7YWomrxhyiWjqbsL558/D1Ey+vcL4NopRMCDKIipjFQz/dhgt21uQOp6CltUQ3RJF87Zm2Lo9pRPsXFVFAPiKjEeGEprIu9HGNVjG1InMsiojEAtAz+nQSzrMiolKsoL2+9oR2xWDGlZx6menYJQNyG4Zsk+GYzqoZqpwTActN7fA3eRGcbCIaqkKYZwn9IIB5ZEyXAEX3F43ZIX/JyzJEir5CqrHeG6OpVtgDoNlWHBMB94WL4yCgdP/72m03tq64GGQhBCyXChQIdeE4zjI9edgFAwoIQXh7jAC8cCcc3XqjcuMioFTPz2FzNkMwhvCcPlcSB1PwR/zAwKQPZ9FJVVp9AwRXSKsqoXk8SSSR5Loub+HT2b2uVBNV+FYDgQIkN0yHObA5XGhnCrDcRyUhkvofHcnWm9phSRLkPzSlPb63R/pnrWqyHEcFIYKiO2MIdwdbjyuNquQFRm18tTgRlZl+Dw+QALgAFse2ILuu7shCAI2fHAD0qfSqCQryA/m4WvxAe98K2+LFy23tqA6VoW3xcuremwGl88FvaDDrtnInc2hGuSBXT0npZQooVauQZAFiIII2c9XUyzDQjVVhS/mQ3G4iIGDA9j+8e2Uq0IIWRUoUCFXLXEsgTM/P4NMX6ax9RPdEsXWB7civjM+bVtock6IXbMx/JthJP6/BESXiMJgAW6fG47l8Nbxqgw1qiJ/IQ/btKEEFDimAwaG5OEk9LyOvl/0QQkpUJoUPqW5asET8cDldcEoGqiVamAOT2x1LAfpk2m4fBN5J5Pb6xt5A1sf3IriUBHp3jRCXaHGLKHCUAHeqBdbH9w6JYCJ74kjsiWC1PHUjCXT1XQVbbe1YeMHN0IQhMb1Sp9Kw6pZ0PM6zKqJ6E1RtN7aikqiwpvWVU2oYRXNW5uRPsnzcxzDgRJWILklCBKvivJEPKgmeSBi6ibAeJ6P5JJ4Aq7pwLEdSIoEs2oidzF31cMUCSFkqYhXPoSQ2dUHBCaPJeFt9qL55mZ4m71IHkvize+8icSxRGNbKNgRbNwcq5kqRo+M4uT/OYnRw6OwTRtqVOWdZbMatJzG8y4YgxJUILh5foZRNmCUDHgjXtz66VvhafLALJuojvEtE8Wv8Bk9pgPHcuDyueAJexqVO+6AG3d+5c7GlkmdrMqwDd5eP74zjtu/cHujzHn89Diq41XEdsZw+xduR3xnfMrXSpKEXZ/ZBTWsYvzUOPScDsd0+LDGU+NQIyp2fWYXJEmacr1CXSF039ONdXeugxJUUElXeKJwVAUEQGlSEOwIwu13N5rNCYIAAQLvXeNTELstBlu3UU7xih9ZkSG7ZZ6cazqAg4lGdQrfXjIr5lUNUySEkKVEKyprCGMM1UwV5WQZAOCP+eGNehe9BTDXgEB3yI10bxpnfn4GbTvaGs815t8MFDD4m0HkL+Yhe2UYeQN6QYe32Qt/m59XsZRryJ3PwSgbjSAidSwFf9yPpvVNkN0yNt2zCed/dR61Yg3pE2m03NKCcHcYzGJwbAembmLon4bgmDxI2Xj3xil9Xeosjc8hqrfXj++Mo21H27TtrGnzhd7R/eFuAMDRA0eR7cuiNFqCrMhou60Nuz6zC90f7p71ekV6IghtDCF1NAUwYM9je3DhpQsYeH0AvmYfzIqJWqUGb4sXsiJDcknwtfpg6RYPWIIKbN1GrVxrrEbJHhmCxMcSgAG1ag12zYbL64LL57riGAFCCFkp6P9Wa0QpUUL/q/0Y+IcBVFIV2LYNX6sPne/uxNYHti4quXKuAYGiKCLUFZpSyjt5/o1t2ygOFxudaJnAYFUsaOBzeoIdQd4/JKehPFqG2sKrcwoXCzA1E+OnxhHuCfNtpq1RpI6m4JgOUsdTqGariPZEwRjD8G+HYRs2PE0erPvAOj4D6LJYgzGGcqLcKGOe/B7qJcjz0f3hbmz44AYkDiegjWtQm1XE98QbnWnnul6SJCHSHUE5UYZLcaHnIz3IXcjxbSHNhFk14WvxNXrEGEWDjx0Q+eoKcxgcy+El26kqD2J8LkAAapUaADTKxcMbw3MOUySEkJWEApU1oJQo4a0fvIWLv77IB/RZNp8rcy6L5NEkEkcTuP3x6VsaV7KQUt7J82+auptw6R8vwdItBNcF+V/9SfDutkyCUTJQyVRQHa9CcknoeHcHWm5pga/FB7vGhxqOnx6HntVRyVQgQMCWB7ag/8V+1Mo1lIZKMPIGbJ0PIpRVGeGeMMZPjoM5DCf++gQ2fGADWm5ugaVZKCfK8IQ9iO+OX3WCqSRJ6Ly986qvV3xPHD37e5A8mgQDQ2m0hEqmArkgg4HBKBpQwyqMogHHcfhqjyzygMV0oBd0mGUTjuMADAh0BiC6eeC1/q71lEhLCFk1rmuOyt///d/jjjvugKqqCIfDeOCBB6Y8Pzg4iPvvvx9erxetra344z/+Y1gW7Z1fS4wx9L/aj4u/vgijZAACIEoilIACt88Nu8bbsx/94VEUR4sLeu3JpbwzmVzKq2U1FAYL8Mf9MMsmjLwBd8ANZrFGXobiU+AJeSDKIt9yyRlo3tKMdXeuQ6Q7AiWowNvsxfr3rcdN/+ImPnHY60LHvg4E4gHc8olb+LYOA2pFvtUheSSEu8OQFRmRnghie2IwCgbO/t1ZDP3zEPS8juiWKHo+0gNfmw+ZcxmMvjWKzLkMv8lfQwu5XoIgoH1PO5jNcOGlCygnyjzJNqtBy2iQ3BIC7QG0bG9BZFMEO39/J7rv7YavxQfZI8Pl5VtCbp8b/pgfgVgALdtacNvDt1FpMiFkVbluKyo/+9nP8Mgjj+Ab3/gGPvjBD8KyLPT29jaet20b999/P2KxGH77298ikUjg3/ybfwOXy4VvfOMb1+u01pxqpoqBfxhoVNzYug13wA1BECAqIizTgqVbGD8zjoF/HMD2T8y/bHWuAYGXl/KWE+VGFY+e1yFIArwRL7ScBk/YwxNFXQKCXXyFJXk0CXfQjbbb2vhKAWNTmsYxh6GcKiMQCyDblwWz+Yyg+LviuPTrS43z8DZ7EegIwNPkQSAWgDvgRmRTBIkjCTiOg5s/djN8zT4kjyfx1vffmrVy6VpYyPUCeJBZGC7ANm14W73QMhpqWg0uj4tXImk1pE+mse4967Dpw5sAAM03NWP4jWFkL2RhVk0ofgXBziDadrRh/V3rKUghhKw61yVQsSwLX/ziF/Htb38bn/3sZxuPb9u2rfHvL7/8Mk6dOoVXX30VbW1t2LlzJ/7Df/gPePLJJ/H1r38dbvfMy+NkYcrJMu9B8s6sHNnDe2vYBk++rJVrsKoWGGM49+I5tN3WhtZbWuf12qIozruUV/bIkBSJJ626JEguCWpEhamZ0HM6ZLfM81UsB4UBnociyiIGXh+A2++Gt9WLyKZII7eiMMBLidWwCsXNq4LMiomRN0amnKOe1RFaF4Kv1dcIdERJRLQnivJoGUbeQGmkhDe/8yaqmeqU95A8lkRxqDhjpc9iLOR6McYwcHAAek5H151dECBAL+jQshpqlRqMvMHLqtv86LijozFs0H+/H537OnmZtsY707pU15SScEIIWU2uy9bPkSNHMDIyAlEUsWvXLsTjcezfv3/KisqhQ4dw6623oq2trfHYvffei2KxiJMnT8762oZhoFgsTvkgVyACEHi5qiDzIKWarkLLarA1nq9iVS2kT6Vx8v+cRClRmvdLz7eUt96qvpwow+V3wdvKpwA3bWyCy+dCKVmCUTSQ7k0jczrTGAJYSpTAGENpuITRw6PQshpvLnchB0EUUKvWUE6Vkb+Yx/Bvh3kg5JHQemsrBEmAWTVx+qenUStO3W5xB9ywdAtaTsPpn59GcbSI4PogJIX3J/GEPWjZ3oJqpoozPz9zzbaB5nu9tKyG/KU8r9LxuODyuhCI8+2btu1tiO2KIdAeQKCdrxbV1UvBQ50hRDdHEeoMXVVlFyGELLfrsqJy4cIFAMDXv/51/MVf/AU2bNiA//yf/zPe//734+zZs4hEIkgmk1OCFACNz5PJ5Kyv/cwzz+Dpp5++Hqd9Q/LH/Ah1haDndFg1Cy7LBT2vwygZEEQBjDGIstjYfkkdT+HCqxew41M75n1zm08pryAIjZb6+f48/G1+FIeKSJ1IwSybjRk3lVIFnpAHXXd2wTZtjPeOI30yjeZbmlEr1TB2cgxuP58crIQUVNNVeCNe5C7keE6KW0J4Yxi1Sg3BdbxCRs/rePuv3saOT+9otL6v54PkLuQw8I8DAIDMmQzP3wkpjW2iyyuXroX5XC9L58MEXV5XY8usfh1dXl5eXBgsQJREKjUmhNzQFrSi8uUvf5k3nJrj48yZib8+v/KVr+CjH/0o9uzZgwMHDkAQBPz0pz+9qhN+6qmnUCgUGh9DQ0NX9Xo3Om/Ui859nfBEPBAlEeVkGVpeA2OMDwJ0HCghpTHVWPbJGP7dMKqZ6oK+T72Ut31vO6KbozP2G6m31I9uicIoGtAzOpyaA0/IA7ffDUEUILpFuIM8f8PX7ENsTwwu1YXSYAm2ZaM4WIQ34oXskRHeGIbb50b6VBq2/k57/pui0Es8B6ZzXyc67uiAp8nTCFaMgtHIB/G3+zF2cgzVTBWeoAeeJg9kD5+snO3PolaqNVZeJg8hvBaudL3qHXyVoAItx39ek1m6BatqoWlDE5UaE0JuaAv6U+yJJ57Aww8/POcxmzZtQiKRADA1J0VRFGzatAmDg4MAgFgshjfffHPK16ZSqcZzs1EUBYoyvWEXmZkgCNh09yZU01UIkoCx42OolWqQ3BJESYQn6IGvzQe1SUUgFoAgCigMFlBOluFr9l3z8wnEA/Dt98EoGjCrJvxxP4yCgcSRBFyqC4WRAkSIKCVLiPgjcPvdCG8OQ0traL65GbCB1ttaMfjPg/CEPSiNlOCYfAKxv90Px3YQiAfgCXvQ85EenHue590kj/J2+8d/dBztd7Qj2BFEeGMYpdES1LAKx3EgCzIktwRP2AM9p6OULMHb7J02hHApqBEVofUhVFIVWDovoVbDKs/z0S1kz2fRtLGJSo0JITe8BQUqLS0taGlpueJxe/bsgaIo6Ovrw5133gkAME0Tly5dwvr16wEA+/btw5/92Z9hbGwMra08efOVV15BMBicEuCQqxeIB7D9E9sRuSmCvl/24ewvz0Jy8wF/3hbeCba+1WFWzOt+PnpOR+FSAZZmIfV2CpVUBcXBItQWFbABySvBKBiopqvQCzrfqsobYAKDr9kH2+QdVk89d4pPOW7yYPO/2MyDL5eIaqYKs2iiOFREqCuEWrmG6NYoxk6MwSgaSBxOYN8T+5C/kEfL9hbkL+WR689B9soQRd6m3u13Q8vzbaPOOzoR7g7POHhxtk61V2vyVhkA1Dw1HtylePO38MYwlRoTQtaE67K5HQwG8eijj+JrX/saurq6sH79enz7298GADz00EMAgHvuuQfbtm3Dpz/9aXzrW99CMpnEV7/6VTz++OO0YnIdBOIB3HT/TYjeFIVVtaAXdITWhyC7ZcgqrwRijKE8Voav1ccnF18n+YE8EscTsHSrUX2kF3VoBQ2CwBNZZUVGtj8LQRB4UBV0Aw5gGRbSvWn4Yj7EdsaQPJ7EzQ/dDF+LD5ZhoTRSQjVVhdvnhrfZi5ZtLYjtimGsdwyd7+7E6f/3NN731fehbXsbMqczcPvc6Hx3JyrpCooDRd6mXuVl3OWhMlpubcHWB7ci9XZqzsGL18OU6dMDBWhZDYIkoGlDE5UaE0LWjOuWhfftb38bsizj05/+NDRNwx133IHXXnsN4TDvESFJEp5//nk89thj2LdvH3w+H37/938ff/qnf3q9TmnNEwQB0c1RdN/TjbPPn4VZMeFSXADjOQ/VLB/s17mv87pN1mWMYeR3I3xlomIAFiCpEiRZ4jkzhoPyaBmSIsHX5kMgHuAdat0SAvEAYrtjvOGZS8KGD2xA53s7YeQNlFNliC4RDAyyR0Z8Txz+mB+CwCcMd+7rRO58Dvf+3/diw10bUE6WYdUslFNlKCEFGz+4Eam3UyiPlKFlNEAAQutD2PvoXgC4YvnyQuYCLUQgHphz+jQhhNzoBHZ5lt4qUywWEQqFUCgUEAzSX5jzUUqU0PuTXoydGgNzGAQIYGAQRAGtt7Ri+8e3N/pyXGtjJ8fw+jdeR+rtFKyqBW+bF4IjwCjxnBXRLaJWrEHySAitC8HRHcheGbFdMcRui0GNqKiVayhcKsDlc8E232lgJ/HpykP/PARvixdd7+malmRaGCxg9PAoAu0B2KaNsd4xGDkDoQ0heEIeqM0q3H43RJcILa2h6z1d6LmvB6//6etIHE3wRmyM92GRVRmMMaR70/DH/fC2eJE7l1uy1RZCCFnt5nv/prrGNaies5I4nED6dBq1Cp+623JzC+J74gsKUhaSt8EYw+jhUehZPiXZyBuwqu9MAG5S4NgO7JoNURYhyRICsQAC8QAimyONjrUAIKt8u6rrzi6UE2UUBguwqnwbSY2q6LijY1qQkruQw4VXL6AwUEC5swyzYsIx+XTlwmAB8mYZpeFSY+UmehOvyMlfyCN1LAXmMGTOZODYDpjD4Pa64W/3Q1Zk9L/Uj/CmMFpubrluzeIIIWStokBljQrEA40upovdUkgcSywob0PLaqikKlCCCizdQqAjAKPAV1KYwyArMmSPDH/MD+YwxPfE0by1edo5WZoFSZHQtL4J8V3xxraIWTVx4ZULcKmuKcdXM1X0v9qP0kgJaovKu/QKJmSvDNkrwzZtVFIV+GI+VMer8Mf86L63G4F4AOd+dQ75wTw8YQ8kRYJZNWGWTBS1IrIXsrAMi/dsWR+EJ8wbr3nCHrhDbqR70zjz8zNo29F23ZJuCSHkRkeByhpW72K6GIljiQW3nbd0C6IsItgRRGGoACWkwB/3w67ZYDYDBKCSrCC0PgTHdFBNV2G0G1CCSiNYYYyhnCgjuiXaCKzq74ExhszZDDJ9GYR7wo0E4bGTY9DGNbgDbniCHpi6CTWsQnSJ0HM6fFEflJCC+O44JLcEZvGgiTGGwmDhnYsFaBkNTs3hben9LlTTVVRSFbg8LsCeen1EUbwuzeIIIWStoT/zyII5joMzPz+DaqaKlu0tvKvtO91t52o7L3v4iklTdxO8US/Ko+VGN1lRFmEUDUACtLQG5jAUh4o48/MzGPynQVTSFdTKNeTO5+AJexDfHZ+20lIv6fU0eZA7n+PVRHmdzwUqGmA2g+gS4Vi870q9DLlWqcExHbj9bvhafbBrNm+vn9Uabf5LQyVYugWX38W/VhQguAQ4pgPJI6Gm1aY1ZbtezeIIIWQtoRUVsmC5/hwyfRmEukLTtjTmWkmoz/vJ9GWw8UMbcfHXF1EZq0BWZB5A1BzAAUSXiI7bOyB7ZIyfGUe+P4/iUBGx22Jo3dGK+O7Z82imlPQOFpA8lkTyaBK1Ug1mxUR1vApmMTCLwdfqg+gSYddsQAQkl9TYVpI9Mm9jbzLEd8WRPpWGWTEhu2WIbn6uZsWEKInwNnthlvgQQJd3Ytup3qZ/qZvFEULIjYQCFbJgRsGApVtwB2aecO0OuFEcLk5bSZjcxEzP6+j5SA+y/VkUR/ixkiKhKd6ETfdsamzneJu9aNvRhuy5LEIbQujZ33PFfI96Se+lg5dw/qXzEGUR/ri/saJSTpYx3jcOURbh8rlgGRZ8rT64/C7kzucQaA80pg9Lbj7lufnmZmjjGt/+KTkQJRGBeKARmNiWzQcpvqPepj+2M8arhQghhCwKBSpkwZSQAtkj866wYc+05+daSbh8xSPUFWrc8CvJCqI3R6EEJr5OEAR4Qh40b22Gnteh5/R55dUwxnDpHy6BOQytO1pRSVRg6iacmgNvixflRBmZsxl4Ih6EOkMIbwwjdSQFvaA3kmtFt8hb2Fct+GN+NG1sgq3bsA0bolvkCcQuGem+NKqpKsz1JlxeF2qlGgpDBXjCHsR2x5A8krzunWwJIeRGRYEKWbBwdxjRLVEkjyXhDrmn3HxnW0m4vIy5+yPdvDz5nWohUzNx+rnTU7ZOJhMVEcXhIkbeGEFkc+SKN/369lTTuiaIsgiragEAbMmGZfBck1q+Bl/Mh+iWKGrFGrS8BjWsoml9E2RVhqVZqI5VURmv8A66pRrv7VJzoOU0eIIexHbF4Aq4UE6UYZQMVMerkD0yfG0+CKKAkz85Sb1VCCHkKlCgQhZMFEVsfXArikNFpHvTU6p+CkMFeKNebH1wayOQmE8ZczVT5QP3NAtu/9QtpdyFHC69fgnFS0UkjyahBJUr3vQnb0+JsohIdwSlZAl6XoekSzzRtcnCvj/ah3XvXYfBfxqE6BYR2RxpJOm6/W7EdvMBmXpRRzVdRfpkGmpURbA9CH+7H3pWR9v2Nuz7o32wqjxxtjhSxOlfnIae1eddEUUIIWRmFKiQRYnvjOP2L9zeCECKw0XIHhmxnbEpAcR8y5gnJ9rWS4sBHqT0/V0fyskymjY2oXV7K8yyecWb/uXbU+6AGxF/BJZmwbEd1Eo11Co1tO9uh0t1Qc/rCLQHZqwkim6JQstp2PbRbcj2Z/m2kCw2npuc3Os4Dvp+2Qc9q6Nle0sjWKPeKoQQsjgUqJBFi++Mzznj5vIy5ivdtOuJtrnzOfjjfoiKiEuvX2oEKdGeKCSXBCksXfGmP9P2lCAIcHldcBwH+Yv5xvZUOVGGbdiQ1Zn/c5BVGU7KQdOGJnS9p2vOuTuLrYgihBAyMwpUyFURRXHWG+5Cb9qXJ9oWh4soXio2gpTJVUZXuukvZHtK9sizbjvZto2xE2OoJCsYOzUGX8w3ZzLvYiuiCCGEzIwCFXLdLOamPXla8MgbI0geTaJ1eysklzSvr59svttTs207JY8m0f9qP/IX8hAkASO/G0FkSwS7PrML3R/unvF7Xk1FFCGEkOkoUCELZts2EocT0MY1qM0q4nvikKTpgcRib9r1tviRzREoQQVm2YQUnv7687npX2l7qv79Lt92Gu8bR+//0wujYMDT7EHTuiYwmyF1PIWDTx8EgBmDlcVURBFCCJkdBSpkQfpf6cfRA0eR7eMD+WRFnnWV4Wpv2tfqpj/X9lTd5G2n7MUszv7yLIyigaaeJviivkb+ijvkxvipcRw9cBQbPrhhWoC20IooQgghc6P/W5J563+lHwefPojU8RTUqIroTVGoUbWxytD/Sv+U4+s3bW/Ui3RvGnpOh2M50HM60r3pK960r/brFyoQD2DzfZvRvKUZjukgujWKYEdwSpKtKPKhitm+LBKHEzO+Tn3LKbYzhup4FeOnx1EdryK2M0alyYQQskC0okLmxbZtHD1wFFpOQ/O25mkVPLOtMsw3T2Q2V/v1CyUIApjJwBwGb8Q7rVwZ4P1VSqMlaOPanOd9pS0nQgghV0aBCpmXxOEEsn1ZBDuCM1bwTF5l6Ly9c8rzV3vTXuqbvtqsQlZk1Mqz5NaUa5AVGWqzOufrzGfLiRBCyNwoUCHzoo1rsIzp5bt1V1pluNqb9kK+fr7JvrOJ74kjsiWC1PHUjLkxxZEi2m5rQ3wPbeEQQsj1RoEKmZdrtcpwvS0k2Xc2kiRh12d24eDTBzF+ahzBjiDcfjdq5RqKI0WoERW7PrNrQcEPIYSQxaFAZY1gjEHLajA1E5ZmQfJIsHXejdWluqZ1WL3calhlqCf7ajltSnBxpZLimdSPqwc9pdESZEVG221tCwp6CCGEXB0KVNaAUqKExJEExt4eQ/ZCFtWxKkzdhOyR4W/zo2lTE9pubZsys+ZyK32VYbHJvnPp/nA3Nnxww1VtIxFCCLk6FKjc4EqJEs69eA7jp8dRSpRglAxoGQ1myYQ76AYTGGrVGrSshnKyjM33bZ41WFnJqwxXk+w7F0mSFnQ8IYSQa4sClRsYYwwXXr2Aod8MoZQooZwowygZfMvHK6OSqUBOyHD73dCyGrSMBsktYcendsy6DbRSVxmuNtmXEELIykSByg0sfSqN/pf7YekWjKIBS7NglAzAAWrVGiSXBNM0Icoi9KwOl9eF/pf7Ed8dR+strbO+7kpcZVgtyb6EEEIWhrpP3aAYYxh9axS1Yg0uvwul0RKq2SqsioVapYZauQajZMCoGKiOV1EcLsLUTFTGKhg9PArG2HK/hQWpJ/sWR4pwHGfKc/Vk38iWCJUUE0LIKkOByg1Ky2qojFUgqzJy53OoFWtgFgNjvOsqGGDX7Ma/O5aDSrqCWqWG7LkstOzq2iKpJ/uqYRXjp8Z5u32Tt9sfPzW+7Mm+hBBCFoe2fm5Qlm5BkAQwMBhFA5AAZjNIigSnzFccBAiACFi2BVEWIbkkuDwulBIlmJq5zO9g4VZysi8hhJDFoUDlBiV7ZDCbb9+4A25gFBAlEY7t8G2d+s4OA2RRBnMYZLeMwLoAzDLvtbIardRkX0IIIYtDgcoNSo2o8LX6YGs2IpsjKCVKsCoWGBgEUQCzGQRJgCAIECQBSkBB08YmgAFKUJkyMXi1WYnJvoQQQhaHclRuUIIgoH1vO9xBN8yyiWB7EN4WLzxNHigBBa6AC+6gG26fG95mL/wdftiGDcktoWlTE1yqa7nfAiGEEEKByo2sZVsLuu/phhJU4A64IcoiPCEPPCEerMiKDHfADUmR4Al40LSpCYF4AG23tkGNUBkvIYSQ5bd61/fJFQmCgE13b4Jt2hg/zStfHNsBGJDvz8NxHPhiPvhafWjZ1gJRFKFGVMR3x+ec+0MIIYQsFQpUbnCBeACb92+Gv83fmPVTK9UQ2RyB6BLh9rvhb/VD8SsIrQvNOe+HEEIIWWoUqKwBgXgA/vv86Hx3Z2N6sqzKkD38x28bNmSPfMUJyoQQQshSo0BljRAEAd6od7lPgxBCCFkQSqYlhBBCyIpFgQohhBBCViwKVAghhBCyYlGgQgghhJAViwIVQgghhKxYFKgQQgghZMWiQIUQQgghKxYFKoQQQghZsShQIYQQQsiKteo70zLGAADFYnGZz4QQQggh81W/b9fv47NZ9YFKqVQCAHR1dS3zmRBCCCFkoUqlEkKh0KzPC+xKocwK5zgO+vr6sG3bNgwNDSEYDC73Ka04xWIRXV1ddH1mQNdmbnR95kbXZ250fea21q8PYwylUgnt7e0QxdkzUVb9ioooiujo6AAABIPBNfnDni+6PrOjazM3uj5zo+szN7o+c1vL12eulZQ6SqYlhBBCyIpFgQohhBBCVqwbIlBRFAVf+9rXoCjKcp/KikTXZ3Z0beZG12dudH3mRtdnbnR95mfVJ9MSQggh5MZ1Q6yoEEIIIeTGRIEKIYQQQlYsClQIIYQQsmJRoEIIIYSQFYsCFUIIIYSsWDdEoPL3f//3uOOOO6CqKsLhMB544IEpzw8ODuL++++H1+tFa2sr/viP/xiWZS3PyS4TwzCwc+dOCIKAY8eOTXnu7bffxu/93u/B4/Ggq6sL3/rWt5bnJJfQpUuX8NnPfhYbN26Eqqro7u7G1772NdRqtSnHrcVrM9l//+//HRs2bIDH48Edd9yBN998c7lPack988wzeNe73oVAIIDW1lY88MAD6Ovrm3KMrut4/PHHEY1G4ff78dGPfhSpVGqZznh5ffOb34QgCPjSl77UeGytX5+RkRF86lOfQjQahaqquPXWW/HWW281nmeM4U/+5E8Qj8ehqiruvvtunDt3bhnPeIVhq9xzzz3HwuEw+973vsf6+vrYyZMn2d/8zd80nrcsi23fvp3dfffd7OjRo+yFF15gzc3N7KmnnlrGs156X/jCF9j+/fsZAHb06NHG44VCgbW1tbFPfvKTrLe3l/3kJz9hqqqyH/zgB8t3skvgxRdfZA8//DB76aWXWH9/P/vbv/1b1trayp544onGMWv12tQ9++yzzO12sx/+8Ifs5MmT7JFHHmFNTU0slUot96ktqXvvvZcdOHCA9fb2smPHjrH77ruPrVu3jpXL5cYxjz76KOvq6mK//vWv2VtvvcXe/e53s/e85z3LeNbL480332QbNmxgO3bsYF/84hcbj6/l65PNZtn69evZww8/zN544w124cIF9tJLL7Hz5883jvnmN7/JQqEQ+8UvfsGOHz/O/uW//Jds48aNTNO0ZTzzlWNVByqmabKOjg72v/7X/5r1mBdeeIGJosiSyWTjse9973ssGAwywzCW4jSX3QsvvMC2bt3KTp48OS1Q+R//43+wcDg85Vo8+eSTbMuWLctwpsvrW9/6Ftu4cWPj87V+bW6//Xb2+OOPNz63bZu1t7ezZ555ZhnPavmNjY0xAOzgwYOMMcby+TxzuVzspz/9aeOY06dPMwDs0KFDy3WaS65UKrHNmzezV155hd11112NQGWtX58nn3yS3XnnnbM+7zgOi8Vi7Nvf/nbjsXw+zxRFYT/5yU+W4hRXvFW99XPkyBGMjIxAFEXs2rUL8Xgc+/fvR29vb+OYQ4cO4dZbb0VbW1vjsXvvvRfFYhEnT55cjtNeUqlUCo888gj+6q/+Cl6vd9rzhw4dwvve9z643e7GY/feey/6+vqQy+WW8lSXXaFQQCQSaXy+lq9NrVbD4cOHcffddzceE0URd999Nw4dOrSMZ7b8CoUCADR+Vw4fPgzTNKdcq61bt2LdunVr6lo9/vjjuP/++6dcB4Cuz9/93d9h7969eOihh9Da2opdu3bhf/7P/9l4/uLFi0gmk1OuTygUwh133LEmrs98rOpA5cKFCwCAr3/96/jqV7+K559/HuFwGO9///uRzWYBAMlkckqQAqDxeTKZXNoTXmKMMTz88MN49NFHsXfv3hmPWcvXZ7Lz58/ju9/9Lj7/+c83HlvL12Z8fBy2bc/4/m/09z4Xx3HwpS99Ce9973uxfft2APx3we12o6mpacqxa+laPfvsszhy5AieeeaZac+t9etz4cIFfO9738PmzZvx0ksv4bHHHsMXvvAF/OhHPwIw8f8S+m9tdisyUPnyl78MQRDm/Dhz5gwcxwEAfOUrX8FHP/pR7NmzBwcOHIAgCPjpT3+6zO/i+pnv9fnud7+LUqmEp556arlPecnM99pMNjIygo985CN46KGH8MgjjyzTmZPV4PHHH0dvby+effbZ5T6VFWNoaAhf/OIX8eMf/xgej2e5T2fFcRwHu3fvxje+8Q3s2rULn/vc5/DII4/g+9///nKf2qohL/cJzOSJJ57Aww8/POcxmzZtQiKRAABs27at8biiKNi0aRMGBwcBALFYbFqlQj3bPBaLXcOzXjrzvT6vvfYaDh06NG3g1d69e/HJT34SP/rRjxCLxaZl36/m6zPfa1M3OjqKD3zgA3jPe96Dv/zLv5xy3I12bRaiubkZkiTN+P5v9Pc+mz/8wz/E888/j9dffx2dnZ2Nx2OxGGq1GvL5/JRVg7VyrQ4fPoyxsTHs3r278Zht23j99dfx3/7bf8NLL720pq9PPB6fco8CgJtvvhk/+9nPAEz8vySVSiEejzeOSaVS2Llz55Kd54q23EkyV6NQKDBFUaYk09ZqNdba2tqozKgn006uVPjBD37AgsEg03V9yc95KQ0MDLATJ040Pl566SUGgD333HNsaGiIMTaRMFqr1Rpf99RTT62JhNHh4WG2efNm9vGPf5xZljXt+bV8bRjjybR/+Id/2Pjctm3W0dGx5pJpHcdhjz/+OGtvb2dnz56d9nw9WfS5555rPHbmzJk1kyxaLBan/H/mxIkTbO/evexTn/oUO3HixJq/Pp/4xCemJdN+6UtfYvv27WOMTSTT/qf/9J8az9fvbZRMy63qQIUxxr74xS+yjo4O9tJLL7EzZ86wz372s6y1tZVls1nG2ER58j333MOOHTvGfvWrX7GWlpY1V57MGGMXL16cVvWTz+dZW1sb+/SnP816e3vZs88+y7xe7w1fgjs8PMx6enrYhz70ITY8PMwSiUTjo26tXpu6Z599limKwv73//7f7NSpU+xzn/sca2pqmlJBtxY89thjLBQKsX/8x3+c8ntSrVYbxzz66KNs3bp17LXXXmNvvfUW27dvX+NGtBZNrvphbG1fnzfffJPJssz+7M/+jJ07d479+Mc/Zl6vl/31X/9145hvfvObrKmpif3t3/4te/vtt9m/+lf/isqTJ1n1gUqtVmNPPPEEa21tZYFAgN19992st7d3yjGXLl1i+/fvZ6qqsubmZvbEE08w0zSX6YyXz0yBCmOMHT9+nN15551MURTW0dHBvvnNby7PCS6hAwcOMAAzfky2Fq/NZN/97nfZunXrmNvtZrfffjv73e9+t9yntORm+z05cOBA4xhN09i//bf/loXDYeb1etmDDz44Jehday4PVNb69fnlL3/Jtm/fzhRFYVu3bmV/+Zd/OeV5x3HYv//3/561tbUxRVHYhz70IdbX17dMZ7vyCIwxtuT7TYQQQggh87Aiq34IIYQQQgAKVAghhBCyglGgQgghhJAViwIVQgghhKxYFKgQQgghZMWiQIUQQgghKxYFKoQQQghZsShQIYQQQsiKRYEKIYQQQlYsClQIIYQQsmJRoEIIIYSQFev/B8c/JILCyfctAAAAAElFTkSuQmCC",
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "from sklearn.manifold import TSNE\n",
         "import matplotlib\n",
@@ -1051,13 +1788,56 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 18,
       "metadata": {
-        "id": "KdZcBgAOZkFt"
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "KdZcBgAOZkFt",
+        "outputId": "4c778922-e430-45c1-d666-5733d31cde52"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cluster 0 Theme: The common theme in these customer reviews is **pet products, specifically for dogs and cats**. Each review discusses various items related to pet care, including treats, food, and litter. The reviews focus on the effectiveness, convenience, and safety of these products for pets, highlighting experiences with their pets' reactions to the items, the convenience of ordering through subscriptions, and preferences for American-made or specific dietary needs for pets. Overall, the reviews reflect the customers' concerns and experiences regarding the quality and suitability of pet-related products.\n",
+            "5, Dogs love it.:   This is the \"all gone\" treat after dinner.  It's the only treat that t\n",
+            "2, Triggered strange vomit response to my dog:   I can't deny that these smell amazing- all the fruitables that I order\n",
+            "4, Very convenient:   Before I order anything online, I try to research as much as possible.\n",
+            "5, These are excellent and excellent $$$$ here at Amazon:   This Old Dawg [Chihuahua] has been eating these for years [Bacon Strip\n",
+            "4, Great food!:   I wanted a food for a a dog with skin problems. His skin greatly impro\n",
+            "----------------------------------------------------------------------------------------------------\n",
+            "Cluster 1 Theme: The common theme among the customer reviews is a focus on the taste and quality of various beverages, specifically coffee and tea. Each review highlights the reviewers' personal experiences and preferences regarding flavor and satisfaction with the products they've tried. They also touch on aspects like brewing methods, specific brands, and some mention pricing or value related to the products. Overall, the reviews reflect a shared interest in enjoyable and high-quality beverage options.\n",
+            "5, Emerils Big Easy:   Best coffee available, I drink it on the middle setting of the five ou\n",
+            "1, Buyer beware:   Nespresso makes GREAT coffee and GREAT machines. The Nespresso capsule\n",
+            "5, Always delicious!:   Green Mountain has never let me down as far as taste.  Always deliciou\n",
+            "4, Like this tea:   This tea has a nice flavor although I wish it was a little stronger.  \n",
+            "5, chocolate heaven:   Excellent smooth taste. Any one who loves chocolate will enjoy this dr\n",
+            "----------------------------------------------------------------------------------------------------\n",
+            "Cluster 2 Theme: The common theme among the customer reviews is **disappointment and mixed experiences with food products**. Each review reflects a different aspect of that theme:1. The first review appreciates a gluten-free licorice but focuses on the positive aspect of finding a suitable snack.2. The second review expresses strong disappointment with receiving mini candy bars instead of the expected standard size, emphasizing customer frustration over the misleading product description.3. The third review is positive, with the customer delighted by the taste and quality of the toasted chips, showcasing a successful experience.4. The fourth review is highly critical of a fraudulent purchase related to a product (sour Starbursts), indicating a severe negative experience due to issues with the seller and delivery.5. The fifth review points out dissatisfaction due to the product being sticky, which detracted from the eating experience, despite not having issues with the product itself.Overall, the reviews delve into consumer expectations versus reality, with a mix of satisfaction and significant dissatisfaction around food products and purchasing experiences.\n",
+            "5, Licorice for the Gluten Free:   It is a very good tasting alternative to other licorice. Being Gluten \n",
+            "2, these are mini candy bars.:   I was very disappointed with this order because no where on the descri\n",
+            "3, its delicious...:   I was surprised at how delicious these toasted chips are. They ship we\n",
+            "1, The Seller is NOT Starbursts:   As I ordered this for my boyfriend for his birthday as he LOVES the so\n",
+            "3, The Kind Plus item was sticky:   I have no complaint about the product itself. I likely would have rate\n",
+            "----------------------------------------------------------------------------------------------------\n",
+            "Cluster 3 Theme: The common theme among these customer reviews is the expression of strong opinions regarding the quality and efficacy of various products. Each review demonstrates either extreme satisfaction or dissatisfaction, highlighting personal experiences and preferences. 1. **Extremes of Experience:** The first review expresses vehement dissatisfaction with a bacon-flavored mayonnaise, while subsequent reviews (like the one about the popcorn or the faucet) convey enthusiastic approval, showcasing either love or aversion.   2. **Personal Connection:** Each review touches on how the product affects the reviewer’s life, whether it’s enhancing cooking experiences, aiding convenience, or causing disappointment.3. **Clarity of Opinion:** The reviews clearly communicate the reviewer's feelings towards the product, whether positive or negative, often using descriptive language to emphasize their point of view.This theme illustrates how personal taste can greatly influence customer satisfaction across a range of products, from food items to household goods.\n",
+            "1, God Awful:   As a dabbler who enjoys spanning the entire spectrum of taste, I am mo\n",
+            "5, Love This Stuff:   Great variety and comes in a package that does not crush during delive\n",
+            "5, Colorado Spice Orange Peel, Fine Cut:   It was more then I needed but I'm glad I bought in bulk. This product \n",
+            "5, Yum:   Yum, Yum, Yum, Yum...  (Munch, munch).  Yum!  Love it and it tastes wo\n",
+            "5, Love this faucet:   Love this faucet.  My husband had installed the same one in our old ho\n",
+            "----------------------------------------------------------------------------------------------------\n"
+          ]
+        }
+      ],
       "source": [
         "import openai\n",
+        "\n",
+        "from openai import OpenAI\n",
+        "\n",
+        "client = OpenAI()\n",
         "\n",
         "# Reading a review that belongs to each group.\n",
         "rev_per_cluster = 5\n",
@@ -1072,16 +1852,21 @@
         "        .sample(rev_per_cluster, random_state=42)\n",
         "        .values\n",
         "    )\n",
-        "    response = openai.Completion.create(\n",
-        "        engine=\"davinci-002\",\n",
-        "        prompt=f'What do the following customer reviews have in common?\\n\\nCustomer reviews:\\n\"\"\"\\n{reviews}\\n\"\"\"\\n\\nTheme:',\n",
-        "        temperature=0,\n",
-        "        max_tokens=64,\n",
-        "        top_p=1,\n",
-        "        frequency_penalty=0,\n",
-        "        presence_penalty=0,\n",
+        "\n",
+        "\n",
+        "    chat_completion = client.chat.completions.create(\n",
+        "        messages=[\n",
+        "            {\n",
+        "                \"role\": \"user\",\n",
+        "                \"content\": f'What do the following customer reviews have in common?\\n\\nCustomer reviews:\\n\"\"\"\\n{reviews}\\n\"\"\"\\n\\nTheme:',\n",
+        "            }\n",
+        "        ],\n",
+        "        model=\"gpt-4o-mini\", # you may choose a model here\n",
         "    )\n",
-        "    print(response[\"choices\"][0][\"text\"].replace(\"\\n\", \"\"))\n",
+        "\n",
+        "\n",
+        "    print(chat_completion.choices[0].message.content.replace(\"\\n\", \"\"))\n",
+        "\n",
         "\n",
         "    sample_cluster_rows = df[df.Cluster == i].sample(rev_per_cluster, random_state=42)\n",
         "    for j in range(rev_per_cluster):\n",
@@ -1103,10 +1888,7 @@
     }
   ],
   "metadata": {
-    "accelerator": "GPU",
     "colab": {
-      "gpuType": "L4",
-      "machine_shape": "hm",
       "provenance": []
     },
     "kernelspec": {
@@ -1125,7 +1907,6 @@
       "pygments_lexer": "ipython3",
       "version": "3.9.9"
     },
-    "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
         "hash": "365536dcbde60510dc9073d6b991cd35db2d9bac356a11f5b64279a5e6708b97"


### PR DESCRIPTION
I updated Transfer_Learning_with_Ada_Embeddings.ipynb to use the latest `openai `version 1.57. `httpx `had to be downgraded from 0.28 to 0.27.2 in order not to use the "proxies" argument in `OpenAI()` initializer.